### PR TITLE
chore(helm): run migrations in sync before dependent deployments

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: liquio
 description: A Helm chart for Liquio platform
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "0.1.0"
 icon: https://raw.githubusercontent.com/liquio/liquio/refs/heads/main/helm-chart/icon.svg

--- a/helm-chart/templates/admin/admin-api.deployment.yaml
+++ b/helm-chart/templates/admin/admin-api.deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/component: admin-api
     app.kubernetes.io/tier: backend
     app.kubernetes.io/exposure: public
+  annotations:
+    "argocd.argoproj.io/sync-wave": "2"
 spec:
   replicas: {{ .Values.services.adminApi.replicaCount }}
   selector:

--- a/helm-chart/templates/core-services/event.deployment.yaml
+++ b/helm-chart/templates/core-services/event.deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/component: event
     app.kubernetes.io/tier: backend
     app.kubernetes.io/exposure: internal
+  annotations:
+    "argocd.argoproj.io/sync-wave": "2"
 spec:
   replicas: {{ .Values.services.event.replicaCount }}
   selector:

--- a/helm-chart/templates/core-services/filestorage-migrations.job.yaml
+++ b/helm-chart/templates/core-services/filestorage-migrations.job.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
-    "argocd.argoproj.io/hook": PostSync
+    "argocd.argoproj.io/hook": Sync
     "argocd.argoproj.io/sync-wave": "1"
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
 spec:

--- a/helm-chart/templates/core-services/manager-migrations.job.yaml
+++ b/helm-chart/templates/core-services/manager-migrations.job.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
-    "argocd.argoproj.io/hook": PostSync
+    "argocd.argoproj.io/hook": Sync
     "argocd.argoproj.io/sync-wave": "1"
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
 spec:

--- a/helm-chart/templates/core-services/manager.deployment.yaml
+++ b/helm-chart/templates/core-services/manager.deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/component: manager
     app.kubernetes.io/tier: backend
     app.kubernetes.io/exposure: internal
+  annotations:
+    "argocd.argoproj.io/sync-wave": "2"
 spec:
   replicas: {{ .Values.services.manager.replicaCount }}
   selector:

--- a/helm-chart/templates/core-services/notification-migrations.job.yaml
+++ b/helm-chart/templates/core-services/notification-migrations.job.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
-    "argocd.argoproj.io/hook": PostSync
+    "argocd.argoproj.io/hook": Sync
     "argocd.argoproj.io/sync-wave": "1"
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
 spec:

--- a/helm-chart/templates/core-services/register-migrations.job.yaml
+++ b/helm-chart/templates/core-services/register-migrations.job.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
-    "argocd.argoproj.io/hook": PostSync
+    "argocd.argoproj.io/hook": Sync
     "argocd.argoproj.io/sync-wave": "1"
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
 spec:

--- a/helm-chart/templates/core-services/task.deployment.yaml
+++ b/helm-chart/templates/core-services/task.deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/component: task
     app.kubernetes.io/tier: backend
     app.kubernetes.io/exposure: internal
+  annotations:
+    "argocd.argoproj.io/sync-wave": "2"
 spec:
   replicas: {{ .Values.services.task.replicaCount }}
   selector:

--- a/helm-chart/templates/id/id-api.deployment.yaml
+++ b/helm-chart/templates/id/id-api.deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/component: id-api
     app.kubernetes.io/tier: backend
     app.kubernetes.io/exposure: public
+  annotations:
+    "argocd.argoproj.io/sync-wave": "2"
 spec:
   replicas: {{ .Values.services.idApi.replicaCount }}
   selector:

--- a/helm-chart/templates/id/id-migrations.job.yaml
+++ b/helm-chart/templates/id/id-migrations.job.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
-    "argocd.argoproj.io/hook": PostSync
+    "argocd.argoproj.io/hook": Sync
     "argocd.argoproj.io/sync-wave": "1"
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
 spec:


### PR DESCRIPTION
- switch migration jobs from Argo PostSync to Sync to avoid first-install deadlocks

- assign sync wave 2 to dependent deployments so they roll out after migrations

- bump chart version for the hook and ordering changes