### PR TITLE
fix(task): relax p7s id parsing and harden upload response

### DIFF
--- a/task/src/lib/eds/providers/pkcs7.js
+++ b/task/src/lib/eds/providers/pkcs7.js
@@ -245,40 +245,45 @@ class Pkcs7EdsProvider extends EdsProvider {
       let ipnDRFO = null;
       let ipnEDRPOU = null;
 
+      const extractIdentifierPair = (rawValue) => {
+        if (rawValue === undefined || rawValue === null) {
+          return { primary: null, secondary: null };
+        }
+
+        const normalized = String(rawValue).trim();
+        if (!normalized) {
+          return { primary: null, secondary: null };
+        }
+
+        const [primaryRaw, secondaryRaw] = normalized.split('-', 2);
+        const primary = primaryRaw ? primaryRaw.trim() : null;
+        const secondary = secondaryRaw ? secondaryRaw.trim() : null;
+
+        return {
+          primary: primary || null,
+          secondary: secondary || null,
+        };
+      };
+
       // Strategy 1: Get IPN from the certificate subject's serialNumber field
       if (signatureInfo.subject && signatureInfo.subject.serialNumber) {
-        const serialNumber = String(signatureInfo.subject.serialNumber).trim();
-        if (serialNumber) {
-          // Handle cases where serialNumber contains both IPN and EDRPOU separated by dash
-          // Format: IPN-EDRPOU or just IPN
-          const serialParts = serialNumber.split('-');
-          const potentialIpn = serialParts[0].trim();
-
-          // Validate that it looks like an IPN (should be numeric, 8-10 digits)
-          if (/^\d{8,10}$/.test(potentialIpn)) {
-            ipnDRFO = potentialIpn;
-            if (serialParts.length > 1 && /^\d{8,10}$/.test(serialParts[1].trim())) {
-              ipnEDRPOU = serialParts[1].trim();
-            }
-          }
+        const serialIds = extractIdentifierPair(signatureInfo.subject.serialNumber);
+        if (serialIds.primary) {
+          ipnDRFO = serialIds.primary;
+        }
+        if (serialIds.secondary) {
+          ipnEDRPOU = serialIds.secondary;
         }
       }
 
       // Strategy 2: Fallback to personIdentifier if available and IPN not found yet
       if (!ipnDRFO && signatureInfo.subject && signatureInfo.subject.personIdentifier) {
-        const personId = String(signatureInfo.subject.personIdentifier).trim();
-        if (personId) {
-          // personIdentifier might also contain IPN information
-          const personIdParts = personId.split('-');
-          const potentialIpn = personIdParts[0].trim();
-
-          // Validate that it looks like an IPN
-          if (/^\d{8,10}$/.test(potentialIpn)) {
-            ipnDRFO = potentialIpn;
-            if (personIdParts.length > 1 && /^\d{8,10}$/.test(personIdParts[1].trim())) {
-              ipnEDRPOU = personIdParts[1].trim();
-            }
-          }
+        const personIds = extractIdentifierPair(signatureInfo.subject.personIdentifier);
+        if (personIds.primary) {
+          ipnDRFO = personIds.primary;
+        }
+        if (!ipnEDRPOU && personIds.secondary) {
+          ipnEDRPOU = personIds.secondary;
         }
       }
 
@@ -295,7 +300,7 @@ class Pkcs7EdsProvider extends EdsProvider {
       // Strategy 4: Check organizationIdentifier for EDRPOU if not found yet
       if (!ipnEDRPOU && signatureInfo.subject && signatureInfo.subject.organizationIdentifier) {
         const orgId = String(signatureInfo.subject.organizationIdentifier).trim();
-        if (/^\d{8,10}$/.test(orgId)) {
+        if (orgId) {
           ipnEDRPOU = orgId;
         }
       }

--- a/task/src/lib/eds/providers/pkcs7.spec.js
+++ b/task/src/lib/eds/providers/pkcs7.spec.js
@@ -1,0 +1,80 @@
+const Pkcs7EdsProvider = require('./pkcs7');
+
+describe('Pkcs7EdsProvider.getSignatureInfo', () => {
+  beforeEach(() => {
+    global.log = {
+      save: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('extracts short numeric serialNumber as signer DRFO', async () => {
+    const provider = new Pkcs7EdsProvider({});
+
+    jest.spyOn(provider, '_callSignTool').mockResolvedValue({
+      subject: {
+        serialNumber: '1000',
+        commonName: 'Test User',
+      },
+      issuer: {},
+      serial: 'cert-serial',
+      signTime: '2026-05-14T14:08:46.322Z',
+      content: Buffer.from('signed-content').toString('base64'),
+      pem: 'mock-pem',
+    });
+
+    const signature = `MII${'A'.repeat(120)}`;
+    const info = await provider.getSignatureInfo(signature);
+
+    expect(info).toBeTruthy();
+    expect(info.signer.ipn.DRFO).toBe('1000');
+    expect(info.signer.ipn.EDRPOU).toBeNull();
+  });
+
+  it('extracts non-numeric personIdentifier as signer DRFO', async () => {
+    const provider = new Pkcs7EdsProvider({});
+
+    jest.spyOn(provider, '_callSignTool').mockResolvedValue({
+      subject: {
+        personIdentifier: 'TESTIDENTIFIER01',
+      },
+      issuer: {},
+      serial: 'cert-serial',
+      signTime: '2026-05-14T14:08:46.322Z',
+      content: Buffer.from('signed-content').toString('base64'),
+      pem: 'mock-pem',
+    });
+
+    const signature = `MII${'A'.repeat(120)}`;
+    const info = await provider.getSignatureInfo(signature);
+
+    expect(info).toBeTruthy();
+    expect(info.signer.ipn.DRFO).toBe('TESTIDENTIFIER01');
+    expect(info.signer.ipn.EDRPOU).toBeNull();
+  });
+
+  it('extracts both DRFO and EDRPOU from serialNumber pair', async () => {
+    const provider = new Pkcs7EdsProvider({});
+
+    jest.spyOn(provider, '_callSignTool').mockResolvedValue({
+      subject: {
+        serialNumber: '1234567890-87654321',
+      },
+      issuer: {},
+      serial: 'cert-serial',
+      signTime: '2026-05-14T14:08:46.322Z',
+      content: Buffer.from('signed-content').toString('base64'),
+      pem: 'mock-pem',
+    });
+
+    const signature = `MII${'A'.repeat(120)}`;
+    const info = await provider.getSignatureInfo(signature);
+
+    expect(info).toBeTruthy();
+    expect(info.signer.ipn.DRFO).toBe('1234567890');
+    expect(info.signer.ipn.EDRPOU).toBe('87654321');
+  });
+});

--- a/task/src/lib/filestorage.js
+++ b/task/src/lib/filestorage.js
@@ -311,8 +311,8 @@ class FileStorage {
         body: buffer,
       });
 
-      // Parse response body - axios should automatically parse JSON, but handle both cases
-      let responseData = response.data;
+      // Support both response shapes: body object and legacy { data: body }.
+      let responseData = response && Object.prototype.hasOwnProperty.call(response, 'data') ? response.data : response;
       if (typeof responseData === 'string') {
         try {
           responseData = JSON.parse(responseData);
@@ -320,6 +320,12 @@ class FileStorage {
           log.save('filestorage-upload-from-stream-error', { name, body: responseData, error: parseError && parseError.message });
           throw parseError;
         }
+      }
+
+      if (!responseData) {
+        const error = new Error('Empty response body from filestorage upload');
+        log.save('filestorage-upload-from-stream-error', { name, error: error.message });
+        throw error;
       }
 
       // Check for API error in response


### PR DESCRIPTION
- accept non-empty signer identifiers in pkcs7 extraction instead of strict digit-only checks

- support legacy and direct filestorage upload response shapes with explicit empty-response guard