### PR TITLE
fix(admin-api): guard workflow editor debug config access

### DIFF
--- a/admin-api/src/businesses/workflow_handler.js
+++ b/admin-api/src/businesses/workflow_handler.js
@@ -17,6 +17,16 @@ class WorkflowHandlerBusiness {
     // Define singleton.
     if (!WorkflowHandlerBusiness.singleton) {
       this.config = config;
+      this.defaultDebugRepeats = [1, 2, 2, 5, 10];
+
+      const workflowEditorConfig = global.config?.workflow_editor;
+      const debugModeConfig = workflowEditorConfig?.debugMode;
+
+      this.debugModeEnabled = debugModeConfig?.enabled === true;
+      this.debugRepeats = Array.isArray(debugModeConfig?.repeats) && debugModeConfig.repeats.length > 0
+        ? debugModeConfig.repeats
+        : this.defaultDebugRepeats;
+
       WorkflowHandlerBusiness.singleton = this;
     }
 
@@ -73,16 +83,15 @@ class WorkflowHandlerBusiness {
 
     global.messageQueue.produce(name, message);
 
-    if (config.workflow_editor.debugMode && typeof message.debug !== 'undefined' && message.debug === true) {
-      if (config.workflow_editor.debugMode.enabled === false) {
+    if (message.debug === true) {
+      if (this.debugModeEnabled === false) {
         return { error: 'Debug mode is disabled.' };
       }
 
-      let repeat = config.workflow_editor.debugMode.repeats.length;
       let debug;
-      for (let i = 0; i < repeat; i++) {
+      for (let i = 0; i < this.debugRepeats.length; i++) {
         // Wait response.
-        await new Promise((resolve) => setTimeout(resolve, config.workflow_editor.debugMode.repeats[i] * 1000));
+        await new Promise((resolve) => setTimeout(resolve, this.debugRepeats[i] * 1000));
 
         debug = await models.workflowDebug.findById(message.debugId);
         if (debug && debug.data) {

--- a/helm-chart/templates/admin/admin-api.configmap.yaml
+++ b/helm-chart/templates/admin/admin-api.configmap.yaml
@@ -92,6 +92,13 @@ metadata:
   "timeout" 30000
   "url" (printf "http://%s-sign-tool" (include "liquio.fullname" .))
 -}}
+{{ $workflowEditorBase := dict
+  "disabled" false
+  "debugMode" (dict
+    "enabled" false
+    "repeats" (list 1 2 2 5 10)
+  )
+-}}
 data:
   # Auth configuration
   auth.json: |
@@ -144,3 +151,7 @@ data:
   # Sign configuration
   sign.json: |
 {{ include "liquio.renderJsonConfig" (dict "ctx" . "service" "adminApi" "config" "sign.json" "base" $signBase) | nindent 4 }}
+
+  # Workflow editor configuration
+  workflow_editor.json: |
+{{ include "liquio.renderJsonConfig" (dict "ctx" . "service" "adminApi" "config" "workflow_editor.json" "base" $workflowEditorBase) | nindent 4 }}


### PR DESCRIPTION
- initialize debug mode flags once in workflow handler constructor

- add workflow_editor.json to admin-api configmap for runtime config