### PR TITLE
BPP-246 refactor(notification): replace nconf with multiconf config loader

### DIFF
--- a/notification/package-lock.json
+++ b/notification/package-lock.json
@@ -15,7 +15,6 @@
         "moment": "^2.18.1",
         "multiconf": "^4.0.0",
         "mysql": "^2.12.0",
-        "nconf": "^0.13.0",
         "node-cache": "^4.1.1",
         "node-cron": "^1.2.0",
         "nodemailer": "^6.9.1",
@@ -3447,11 +3446,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6155,14 +6149,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ini": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -7472,21 +7458,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/nconf": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.13.0.tgz",
-      "integrity": "sha512-hJ/u2xCpA663h6xyOiztx3y+lg9eU0rdkwJ+c4FtiHo2g/gB0sjXtW31yTdMLWLOIj1gL2FcJMwfOqouuUK/Wg==",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.0.0",
-        "ini": "^2.0.0",
-        "secure-keys": "^1.0.0",
-        "yargs": "^16.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -8505,11 +8476,6 @@
       "engines": {
         "node": ">=11.0.0"
       }
-    },
-    "node_modules/secure-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-      "integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg=="
     },
     "node_modules/select-hose": {
       "version": "2.0.0",

--- a/notification/package.json
+++ b/notification/package.json
@@ -30,7 +30,6 @@
     "moment": "^2.18.1",
     "multiconf": "^4.0.0",
     "mysql": "^2.12.0",
-    "nconf": "^0.13.0",
     "node-cache": "^4.1.1",
     "node-cron": "^1.2.0",
     "nodemailer": "^6.9.1",

--- a/notification/src/config/config.js
+++ b/notification/src/config/config.js
@@ -1,41 +1,30 @@
-const nconf = require('nconf');
+const Multiconf = require('multiconf');
 const fs = require('fs');
 const path = require('path');
 
-const configDir = process.env.CONFIG_PATH || path.join(process.cwd(), '../config/notification');
-if (!fs.existsSync(configDir)) {
+const CONFIG_PATH = process.env.CONFIG_PATH || path.join(process.cwd(), '../config/notification');
+const SECRET_PATH = process.env.SECRET_PATH;
+const LIQUIO_CONFIG_PREFIX = process.env.LIQUIO_CONFIG_PREFIX || 'LIQUIO_CFG_NOTIFICATION';
+
+if (!fs.existsSync(CONFIG_PATH)) {
   throw new Error('Config directory does not exist.');
 }
 
-// Init config file.
-const fileConfig = nconf.env().file({ file: path.join(configDir, 'config.json') });
+// Load merged config from CONFIG_PATH and optional SECRET_PATH.
+const mergedConfig = Multiconf.get([CONFIG_PATH, ...(SECRET_PATH && fs.existsSync(SECRET_PATH) ? [SECRET_PATH] : [])], `${LIQUIO_CONFIG_PREFIX}_`).config;
 
 // Init config versions.
 const versionsConfText = fs.readFileSync(path.join(process.cwd(), './src/config/versions.json.default'), 'utf8');
 const versionsConf = JSON.parse(versionsConfText || '{}');
 
 // Get NODE_ENV.
-const env = process.env.NODE_ENV || fileConfig.get('default_env') || 'test';
-let envConfig = process.env.LIQUIO_NOTIFY_CONFIG;
+const env = process.env.NODE_ENV || mergedConfig.default_env || 'test';
 if (typeof env !== 'string' || !env) {
   throw new Error(`ENV [${env}] is not defined.`);
 }
 
-let currentEnvConf = fileConfig.get(env);
-if (typeof envConfig === 'string') {
-  try {
-    envConfig = JSON.parse(envConfig);
-    console.log('Successful parsed ENV[LIQUIO_NOTIFY_CONFIG].');
-  } catch {
-    throw new Error('LIQUIO_NOTIFY_CONFIG is invalid json.');
-  }
-
-  if (typeof envConfig[env] === 'undefined') {
-    throw new Error(`LIQUIO_NOTIFY_CONFIG [${env}] is not defined object config.`);
-  }
-
-  currentEnvConf = envConfig[env];
-}
+// Resolve current environment config.
+const currentEnvConf = mergedConfig[env];
 if (typeof currentEnvConf === 'undefined' || typeof currentEnvConf.db === 'undefined') {
   throw new Error('Variable currentEnvConf.db is not defined.');
 }

--- a/notification/src/controllers/test.js
+++ b/notification/src/controllers/test.js
@@ -2,7 +2,7 @@
 const { checkAuth } = require('./auth');
 const Router = require('restify-router').Router;
 const axios = require('axios');
-const conf = require('../config/config');
+const { conf } = require('../config/config');
 
 const routerInstance = new Router();
 

--- a/notification/src/lib/app_ident_headers.js
+++ b/notification/src/lib/app_ident_headers.js
@@ -1,5 +1,5 @@
 const AppInfo = require('./app_info');
-const conf = require('../config/config');
+const { conf } = require('../config/config');
 
 // Constants.
 const DEFAULT_CUSTOMER = '1';


### PR DESCRIPTION
- swap nconf for multiconf to merge CONFIG_PATH + optional SECRET_PATH
- remove LIQUIO_NOTIFY_CONFIG env override (redundant with secret overlay)
- fix config import shape in test.js and app_ident_headers.js ({ conf })