### PR TITLE
fix(notification): replace HMAC auth with standard HTTP Basic auth

### DIFF
--- a/admin-api/src/lib/system_notifier.js
+++ b/admin-api/src/lib/system_notifier.js
@@ -16,11 +16,11 @@ class SystemNotifier {
       this.emailRoutes = global.config.system_notifier.email.routes;
       this.emailTimeout = global.config.system_notifier.email.timeout;
       this.emailUser = global.config.system_notifier.email.user;
-      this.emailHashedPassword = global.config.system_notifier.email.hashedPassword;
+      this.emailPassword = global.config.system_notifier.email.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${global.config.system_notifier.email.user}:${global.config.system_notifier.email.hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${global.config.system_notifier.email.user}:${global.config.system_notifier.email.password}`, 'utf8').toString('base64')}`,
       };
       this.emails = global.config.system_notifier.email.emails;
       this.emailSubject = global.config.system_notifier.email.subject;

--- a/admin-api/src/services/notifier.js
+++ b/admin-api/src/services/notifier.js
@@ -17,11 +17,11 @@ class NotifierService {
       this.port = config.notifier.port;
       this.user = config.notifier.user;
       this.routes = config.notifier.routes;
-      this.hashedPassword = config.notifier.hashedPassword;
+      this.password = config.notifier.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${this.user}:${this.hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${this.user}:${this.password}`, 'utf8').toString('base64')}`,
       };
       this.timeout = config.notifier.timeout || 30000;
       NotifierService.singleton = this;

--- a/cabinet-api/src/lib/notifier/index.ts
+++ b/cabinet-api/src/lib/notifier/index.ts
@@ -31,7 +31,7 @@ export default class Notifier {
   port: number;
   user: string;
   routes: typeof ROUTES;
-  hashedPassword: string;
+  password: string;
   headers: Record<string, string>;
   timeout: number;
   static singleton: Notifier;
@@ -46,11 +46,11 @@ export default class Notifier {
       this.port = global.config.notifier.port;
       this.user = global.config.notifier.user;
       this.routes = { ...ROUTES, ...(global.config.notifier.routes || {}) };
-      this.hashedPassword = global.config.notifier.hashedPassword;
+      this.password = global.config.notifier.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${this.user}:${this.hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${this.user}:${this.password}`, 'utf8').toString('base64')}`,
       };
       this.timeout = global.config.notifier.timeout || 30000;
       Notifier.singleton = this;

--- a/config-templates/admin-api/notifier.json
+++ b/config-templates/admin-api/notifier.json
@@ -3,7 +3,7 @@
   "port": 3003,
   "timeout": 30000,
   "user": "admin-api",
-  "hashedPassword": "<REDACTED>",
+  "password": "<REDACTED>",
   "routes": {
     "ping": "/test/ping",
     "sendToUserList": "/message/usersList",

--- a/config-templates/event/notifier.json
+++ b/config-templates/event/notifier.json
@@ -13,7 +13,7 @@
     },
     "timeout": 30000,
     "user": "<removed>",
-    "hashedPassword": "<removed>",
+    "password": "<removed>",
     "templateParams": {
       "frontUrl": "https://front-dev-oe.liquio.local"
     },
@@ -29,7 +29,7 @@
       "ping": "/test/ping"
     },
     "user": "<removed>",
-    "hashedPassword": "<removed>",
+    "password": "<removed>",
     "templateParams": {
       "frontUrl": "https://front-dev-oe.liquio.local"
     }

--- a/config-templates/event/system_notifier.json
+++ b/config-templates/event/system_notifier.json
@@ -10,7 +10,7 @@
     },
     "timeout": 30000,
     "user": "<removed>",
-    "hashedPassword": "<removed>",
+    "password": "<removed>",
     "emails": [],
     "subject": "Workflow process problem.",
     "body": "<html><body>Відбулась помилка в процесі {url}<br/>Event {eventTemplateId} {eventTemplateName}<br/>{error}</body></html>"

--- a/config-templates/gateway/system_notifier.json
+++ b/config-templates/gateway/system_notifier.json
@@ -10,7 +10,7 @@
     },
     "timeout": 30000,
     "user": "<removed>",
-    "hashedPassword": "<removed>",
+    "password": "<removed>",
     "emails": [],
     "subject": "Workflow process problem.",
     "body": "<html><body>Відбулась помилка в процесі {url}<br/>Gateway {gatewayTemplateId} {gatewayTemplateName}<br/>{error}</body></html>"

--- a/config-templates/manager/system_notifier.json
+++ b/config-templates/manager/system_notifier.json
@@ -10,7 +10,7 @@
     },
     "timeout": 30000,
     "user": "<removed>",
-    "hashedPassword": "<removed>",
+    "password": "<removed>",
     "emails": [],
     "subject": "Workflow process problem.",
     "body": "<html><body>Відбулась помилка в процесі {url}<br/>{error}</body></html>"

--- a/config-templates/task/notifier.json
+++ b/config-templates/task/notifier.json
@@ -3,7 +3,7 @@
   "port": 3003,
   "timeout": 30000,
   "user": "<removed>",
-  "hashedPassword": "<removed>",
+  "password": "<removed>",
   "clientId": "",
   "routes": {
     "ping": "/test/ping",

--- a/config-templates/task/system_notifier.json
+++ b/config-templates/task/system_notifier.json
@@ -10,7 +10,7 @@
     },
     "timeout": 30000,
     "user": "<removed>",
-    "hashedPassword": "<removed>",
+    "password": "<removed>",
     "emails": [],
     "subject": "Workflow process problem.",
     "body": "<html><body>Відбулась помилка в процесі {url}<br/>Task {taskTemplateId} {taskTemplateName}<br/>{error}</body></html>"

--- a/event/src/lib/system_notifier.js
+++ b/event/src/lib/system_notifier.js
@@ -16,11 +16,11 @@ class SystemNotifier {
       this.emailRoutes = global.config.system_notifier.email.routes;
       this.emailTimeout = global.config.system_notifier.email.timeout;
       this.emailUser = global.config.system_notifier.email.user;
-      this.emailHashedPassword = global.config.system_notifier.email.hashedPassword;
+      this.emailPassword = global.config.system_notifier.email.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${global.config.system_notifier.email.user}:${global.config.system_notifier.email.hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${global.config.system_notifier.email.user}:${global.config.system_notifier.email.password}`, 'utf8').toString('base64')}`,
       };
       this.emails = global.config.system_notifier.email.emails;
       this.emailSubject = global.config.system_notifier.email.subject;

--- a/event/src/services/event/notifier/email/providers/liquio.js
+++ b/event/src/services/event/notifier/email/providers/liquio.js
@@ -20,13 +20,13 @@ class LiquioProvider extends Provider {
       super();
 
       // Save params.
-      const { server, port, routes, timeout, user, hashedPassword, templateParams = {}, defaultTemplateId, clientId } = config;
+      const { server, port, routes, timeout, user, password, templateParams = {}, defaultTemplateId, clientId } = config;
       const headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${user}:${hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${user}:${password}`, 'utf8').toString('base64')}`,
       };
-      Object.assign(this, { config, server, port, routes, timeout, user, hashedPassword, templateParams, defaultTemplateId, clientId, headers });
+      Object.assign(this, { config, server, port, routes, timeout, user, password, templateParams, defaultTemplateId, clientId, headers });
 
       // Init singleton.
       LiquioProvider.singleton = this;

--- a/event/src/services/event/notifier/sms/providers/liquio.js
+++ b/event/src/services/event/notifier/sms/providers/liquio.js
@@ -20,11 +20,11 @@ class LiquioProvider extends Provider {
       this.port = config.port;
       this.routes = config.routes;
       this.user = config.user;
-      this.hashedPassword = config.hashedPassword;
+      this.password = config.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${this.user}:${this.hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${this.user}:${this.password}`, 'utf8').toString('base64')}`,
       };
       LiquioProvider.singleton = this;
     }

--- a/gateway/src/lib/system_notifier.js
+++ b/gateway/src/lib/system_notifier.js
@@ -16,11 +16,11 @@ class SystemNotifier {
       this.emailRoutes = global.config.system_notifier.email.routes;
       this.emailTimeout = global.config.system_notifier.email.timeout;
       this.emailUser = global.config.system_notifier.email.user;
-      this.emailHashedPassword = global.config.system_notifier.email.hashedPassword;
+      this.emailPassword = global.config.system_notifier.email.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${global.config.system_notifier.email.user}:${global.config.system_notifier.email.hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${global.config.system_notifier.email.user}:${global.config.system_notifier.email.password}`, 'utf8').toString('base64')}`,
       };
       this.emails = global.config.system_notifier.email.emails;
       this.emailSubject = global.config.system_notifier.email.subject;

--- a/helm-chart/templates/shared/init-secrets.job.yaml
+++ b/helm-chart/templates/shared/init-secrets.job.yaml
@@ -61,7 +61,7 @@ spec:
               FILESTORAGE_TOKEN="Basic $(printf "filestorage:%s" "$(openssl rand -base64 32)" | base64 | tr -d '\n')"
               NOTIFY_LOGIN="notification"
               NOTIFY_PASSWORD="$(openssl rand -base64 32)"
-              NOTIFY_HASH="$(echo -n "$NOTIFY_PASSWORD" | openssl dgst -sha512 -hmac "$NOTIFY_LOGIN" | awk '{print $2}' | tr '[:lower:]' '[:upper:]')"
+              NOTIFY_TOKEN="Basic $(printf "%s:%s" "$NOTIFY_LOGIN" "$NOTIFY_PASSWORD" | base64 | tr -d '\n')"
 
               kubectl create secret generic {{ printf "%s-infra-secrets" (include "liquio.fullname" .) }} \
                 --namespace "$NAMESPACE" \
@@ -93,8 +93,8 @@ spec:
               ADMIN_API_REGISTER_JSON="$(jq -cn --arg token "$REGISTER_TOKEN" '{token: $token}')"
               ADMIN_API_SERVER_JSON="$(jq -cn --arg oauth "$OAUTH_SECRET" --arg jwt "$JWT_SECRET" '{crypto: {iv: $oauth, password: $jwt}, token: $oauth}')"
               ADMIN_API_ELASTIC_JSON="$(jq -cn --arg oauth "$OAUTH_SECRET" '{headers: {Authorization: ("Basic " + $oauth)}}')"
-              ADMIN_API_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{user: $user, hashedPassword: $password}')"
-              ADMIN_API_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, hashedPassword: $password}}')"
+              ADMIN_API_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{user: $user, password: $password}')"
+              ADMIN_API_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, password: $password}}')"
               ADMIN_API_SIGN_JSON="$(jq -cn --arg oauth "$OAUTH_SECRET" '{token: $oauth}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "admin-api") }} \
@@ -118,7 +118,7 @@ spec:
                 --from-literal=db.json="$CABINET_API_DB_JSON" \
                 --from-literal=auth.json="$CABINET_API_AUTH_JSON"
 
-              ID_CONFIG_JSON="$(jq -cn --arg password "$POSTGRES_PASSWORD" --arg oauth "$OAUTH_SECRET" --arg jwt "$JWT_SECRET" --arg notifyAuth "Basic $NOTIFY_LOGIN:$NOTIFY_PASSWORD" '{production: {db: {password: $password}, session: {secret_key: $oauth}, jwt: {secret: $jwt}, oauth: {secret_key: [$oauth]}, notify: {authorization: $notifyAuth}}}')"
+              ID_CONFIG_JSON="$(jq -cn --arg password "$POSTGRES_PASSWORD" --arg oauth "$OAUTH_SECRET" --arg jwt "$JWT_SECRET" --arg notifyAuth "$NOTIFY_TOKEN" '{production: {db: {password: $password}, session: {secret_key: $oauth}, jwt: {secret: $jwt}, oauth: {secret_key: [$oauth]}, notify: {authorization: $notifyAuth}}}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "id") }} \
                 --namespace "$NAMESPACE" \
@@ -128,8 +128,8 @@ spec:
               EVENT_MQ_JSON="$(jq -cn --arg amqp "$RABBITMQ_CONNECTION" '{amqpConnection: $amqp}')"
               EVENT_FILESTORAGE_JSON="$(jq -cn --arg token "$FILESTORAGE_TOKEN" '{token: $token}')"
               EVENT_REQUESTER_JSON="$(jq -cn --arg token "$REGISTER_TOKEN" '{registers: {token: $token}}')"
-              EVENT_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, hashedPassword: $password}, sms: {user: $user, hashedPassword: $password}}')"
-              EVENT_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, hashedPassword: $password}}')"
+              EVENT_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, password: $password}, sms: {user: $user, password: $password}}')"
+              EVENT_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, password: $password}}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "event") }} \
                 --namespace "$NAMESPACE" \
@@ -162,7 +162,7 @@ spec:
 
               GATEWAY_DB_JSON="$(jq -cn --arg password "$POSTGRES_PASSWORD" '{password: $password}')"
               GATEWAY_MQ_JSON="$(jq -cn --arg amqp "$RABBITMQ_CONNECTION" '{amqpConnection: $amqp}')"
-              GATEWAY_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, hashedPassword: $password}}')"
+              GATEWAY_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, password: $password}}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "gateway") }} \
                 --namespace "$NAMESPACE" \
@@ -172,7 +172,7 @@ spec:
 
               MANAGER_DB_JSON="$(jq -cn --arg password "$POSTGRES_PASSWORD" '{password: $password}')"
               MANAGER_MQ_JSON="$(jq -cn --arg amqp "$RABBITMQ_CONNECTION" '{amqpConnection: $amqp}')"
-              MANAGER_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, hashedPassword: $password}}')"
+              MANAGER_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, password: $password}}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "manager") }} \
                 --namespace "$NAMESPACE" \
@@ -180,7 +180,7 @@ spec:
                 --from-literal=message_queue.json="$MANAGER_MQ_JSON" \
                 --from-literal=system_notifier.json="$MANAGER_SYSTEM_NOTIFIER_JSON"
 
-              NOTIFICATION_CONFIG_JSON="$(jq -cn --arg dbPassword "$POSTGRES_PASSWORD" --arg hashUser "$NOTIFY_HASH" --arg notifyPassword "$NOTIFY_PASSWORD" '{production: {password: $dbPassword, db: {password: $dbPassword}, authorization: {list: [{user: $hashUser, password: $notifyPassword}]}}}')"
+              NOTIFICATION_CONFIG_JSON="$(jq -cn --arg dbPassword "$POSTGRES_PASSWORD" --arg user "$NOTIFY_LOGIN" --arg notifyPassword "$NOTIFY_PASSWORD" '{production: {password: $dbPassword, db: {password: $dbPassword}, authorization: {list: [{user: $user, password: $notifyPassword}]}}}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "notification") }} \
                 --namespace "$NAMESPACE" \
@@ -205,8 +205,8 @@ spec:
               TASK_STORAGE_JSON="$(jq -cn --arg token "$FILESTORAGE_TOKEN" '{FileStorage: {token: $token}}')"
               TASK_PDF_GENERATOR_JSON="$(jq -cn --arg token "$PDF_GENERATOR_TOKEN" --arg url "http://{{ include "liquio.fullname" . }}-pdf-generator:80/pdf" '{url: $url, basicAuthToken: $token, requestTimeout: 120000}')"
               TASK_DOWNLOAD_TOKEN_JSON="$(jq -cn --arg jwt "$JWT_SECRET" '{jwtSecret: $jwt}')"
-              TASK_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{user: $user, hashedPassword: $password}')"
-              TASK_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, hashedPassword: $password}}')"
+              TASK_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{user: $user, password: $password}')"
+              TASK_SYSTEM_NOTIFIER_JSON="$(jq -cn --arg user "$NOTIFY_LOGIN" --arg password "$NOTIFY_PASSWORD" '{email: {user: $user, password: $password}}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "task") }} \
                 --namespace "$NAMESPACE" \

--- a/manager/src/lib/system_notifier.js
+++ b/manager/src/lib/system_notifier.js
@@ -15,11 +15,11 @@ class SystemNotifier {
       this.emailRoutes = global.config.system_notifier.email.routes;
       this.emailTimeout = global.config.system_notifier.email.timeout || 30000;
       this.emailUser = global.config.system_notifier.email.user;
-      this.emailHashedPassword = global.config.system_notifier.email.hashedPassword;
+      this.emailPassword = global.config.system_notifier.email.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${global.config.system_notifier.email.user}:${global.config.system_notifier.email.hashedPassword}`,
+        Authorization: `Basic ${Buffer.from(`${global.config.system_notifier.email.user}:${global.config.system_notifier.email.password}`, 'utf8').toString('base64')}`,
       };
       this.emails = global.config.system_notifier.email.emails;
       this.emailSubject = global.config.system_notifier.email.subject;

--- a/notification/src/controllers/auth.js
+++ b/notification/src/controllers/auth.js
@@ -20,17 +20,29 @@ const checkAuth = async function (req, res, next) {
     return sendAuthError(res);
   }
 
-  const [login, pass] = authData.split(':');
+  let decodedAuthData;
+  try {
+    decodedAuthData = Buffer.from(authData, 'base64').toString('utf8');
+  } catch (error) {
+    return sendAuthError(res, undefined, 'Authorization token not valid');
+  }
+
+  const separatorIndex = decodedAuthData.indexOf(':');
+  if (separatorIndex === -1) {
+    return sendAuthError(res, undefined, 'Authorization token not valid');
+  }
+
+  const login = decodedAuthData.slice(0, separatorIndex);
+  const pass = decodedAuthData.slice(separatorIndex + 1);
   if (!pass) {
     return sendAuthError(res, undefined, 'Password not match');
   }
 
-  const hmacLogin = crypto.createHmac('sha512', login).update(pass).digest('hex').toUpperCase();
-
   let existedClient;
   if (authConfig.list && Array.isArray(authConfig.list)) {
-    existedClient = authConfig.list.find(({ user, password }) => user === hmacLogin && pass === password);
+    existedClient = authConfig.list.find(({ user, password }) => user === login && pass === password);
   } else {
+    const hmacLogin = crypto.createHmac('sha512', login).update(pass).digest('hex').toUpperCase();
     existedClient = await Authorize.findOne({ where: { login: hmacLogin, password: pass } });
   }
 

--- a/notification/src/controllers/auth.spec.js
+++ b/notification/src/controllers/auth.spec.js
@@ -1,0 +1,80 @@
+const crypto = require('crypto');
+
+jest.mock('../models/authorize', () => jest.fn().mockImplementation(() => ({ Authorize: { findOne: jest.fn() } })));
+
+const AuthorizeModel = require('../models/authorize');
+const { checkAuth } = require('./auth');
+
+const makeRes = () => ({ send: jest.fn() });
+const makeNext = () => jest.fn();
+
+const getFindOneMock = () => AuthorizeModel.mock.results[0].value.Authorize.findOne;
+
+describe('checkAuth', () => {
+  beforeEach(() => {
+    global.conf = { authorization: {} };
+    getFindOneMock().mockReset();
+  });
+
+  it('allows request when base64 token matches plain credentials from config list', async () => {
+    global.conf.authorization.list = [{ user: 'notification', password: 'secret-pass' }];
+    const token = Buffer.from('notification:secret-pass', 'utf8').toString('base64');
+    const req = { headers: { authorization: `Basic ${token}` } };
+    const res = makeRes();
+    const next = makeNext();
+
+    await checkAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.send).not.toHaveBeenCalled();
+    expect(getFindOneMock()).not.toHaveBeenCalled();
+  });
+
+  it('returns auth error when decoded basic payload has no separator', async () => {
+    const token = Buffer.from('notification-secret-pass', 'utf8').toString('base64');
+    const req = { headers: { authorization: `Basic ${token}` } };
+    const res = makeRes();
+    const next = makeNext();
+
+    await checkAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith(401, {
+      code: 'Authorization error',
+      message: 'Authorization token not valid',
+    });
+  });
+
+  it('returns auth error when password is empty', async () => {
+    const token = Buffer.from('notification:', 'utf8').toString('base64');
+    const req = { headers: { authorization: `Basic ${token}` } };
+    const res = makeRes();
+    const next = makeNext();
+
+    await checkAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith(401, {
+      code: 'Authorization error',
+      message: 'Password not match',
+    });
+  });
+
+  it('uses hashed login for DB lookup when config list is absent', async () => {
+    const login = 'notification';
+    const pass = 'secret-pass';
+    const token = Buffer.from(`${login}:${pass}`, 'utf8').toString('base64');
+    const req = { headers: { authorization: `Basic ${token}` } };
+    const res = makeRes();
+    const next = makeNext();
+    const hashedLogin = crypto.createHmac('sha512', login).update(pass).digest('hex').toUpperCase();
+
+    getFindOneMock().mockResolvedValue({ authorize_id: 1 });
+
+    await checkAuth(req, res, next);
+
+    expect(getFindOneMock()).toHaveBeenCalledWith({ where: { login: hashedLogin, password: pass } });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -436,61 +436,60 @@ jq --arg key "$(generate_secret)" \
   server="http://notification"
   login="notification"
   password=$(generate_secret)
-  login_hash=$(node -e 'process.stdout.write(require("crypto").createHmac("sha512", process.argv[1]).update(process.argv[2]).digest("hex").toUpperCase())' $login $password)
-  token="Basic $login:$password"
+  token="Basic $(echo -n "$login:$password" | base64 -w0)"
 
   file="config/notification/config.json"
   echo "$file"
-  jq --arg login "$login_hash" \
-    --arg hash "$password" \
-    '.production.authorization.list = [{ user: $login, password: $hash }]' \
+  jq --arg login "$login" \
+    --arg password "$password" \
+    '.production.authorization.list = [{ user: $login, password: $password }]' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/admin-api/notifier.json"
   echo "$file"
   jq --arg login "$login" \
-    --arg hashedPassword "$password" \
+    --arg password "$password" \
     --arg server "$server" \
-    '.user = $login | .hashedPassword = $hashedPassword | .server = $server' \
+    '.user = $login | .password = $password | .server = $server' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/task/notifier.json"
   echo "$file"
   jq --arg login "$login" \
-    --arg hashedPassword "$password" \
-    '.user = $login | .hashedPassword = $hashedPassword' \
+    --arg password "$password" \
+    '.user = $login | .password = $password' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/event/notifier.json"
   echo "$file"
   jq --arg login "$login" \
-    --arg hashedPassword "$password" \
+    --arg password "$password" \
     --arg server "$server" \
-    '.email.user = $login | .email.hashedPassword = $hashedPassword | .email.server = $server | .sms.user = $login | .sms.hashedPassword = $hashedPassword | .sms.server = $server' \
+    '.email.user = $login | .email.password = $password | .email.server = $server | .sms.user = $login | .sms.password = $password | .sms.server = $server' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/event/system_notifier.json"
   echo "$file"
   jq --arg login "$login" \
-    --arg hashedPassword "$password" \
+    --arg password "$password" \
     --arg server "$server" \
-    '.email.user = $login | .email.hashedPassword = $hashedPassword | .email.server = $server' \
+    '.email.user = $login | .email.password = $password | .email.server = $server' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/gateway/system_notifier.json"
   echo "$file"
   jq --arg login "$login" \
-    --arg hashedPassword "$password" \
+    --arg password "$password" \
     --arg server "$server" \
-    '.email.user = $login | .email.hashedPassword = $hashedPassword | .email.server = $server' \
+    '.email.user = $login | .email.password = $password | .email.server = $server' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/manager/system_notifier.json"
   echo "$file"
   jq --arg login "$login" \
-    --arg hashedPassword "$password" \
+    --arg password "$password" \
     --arg server "$server" \
-    '.email.user = $login | .email.hashedPassword = $hashedPassword | .email.server = $server' \
+    '.email.user = $login | .email.password = $password | .email.server = $server' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/id/config.json"

--- a/task/src/lib/system_notifier.js
+++ b/task/src/lib/system_notifier.js
@@ -17,11 +17,11 @@ class SystemNotifier {
       this.emailRoutes = global.config.system_notifier.email.routes;
       this.emailTimeout = global.config.system_notifier.email.timeout;
       this.emailUser = global.config.system_notifier.email.user;
-      this.emailHashedPassword = global.config.system_notifier.email.hashedPassword;
+      this.emailPassword = global.config.system_notifier.email.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${global.config.system_notifier.email.user}:${global.config.system_notifier.email.hashedPassword}`
+        Authorization: `Basic ${Buffer.from(`${global.config.system_notifier.email.user}:${global.config.system_notifier.email.password}`, 'utf8').toString('base64')}`
       };
       this.emails = global.config.system_notifier.email.emails;
       this.emailSubject = global.config.system_notifier.email.subject;

--- a/task/src/services/notifier.js
+++ b/task/src/services/notifier.js
@@ -29,11 +29,11 @@ class NotifierService {
       this.port = config.notifier.port;
       this.user = config.notifier.user;
       this.routes = { ...ROUTES, ...(config.notifier.routes || {}) };
-      this.hashedPassword = config.notifier.hashedPassword;
+      this.password = config.notifier.password;
       this.headers = {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Basic ${this.user}:${this.hashedPassword}`
+        Authorization: `Basic ${Buffer.from(`${this.user}:${this.password}`, 'utf8').toString('base64')}`
       };
       this.timeout = config.notifier.timeout || 30000;
       this.clientId = config.notifier.clientId;


### PR DESCRIPTION
- notification checkAuth now decodes base64 credentials from Authorization header
- config-list path uses plain credential comparison instead of HMAC-SHA512
- all notifier clients (admin-api, cabinet-api, task, event, gateway, manager) encode Authorization header as Basic base64(user:password)
- rename hashedPassword -> password in all notifier config fields and templates
- init.sh and helm init-secrets job generate plain password and base64 token