### PR TITLE
fix(admin-front): show toast for test-user admin denial

### DIFF
--- a/admin-front/src/application/actions/users.js
+++ b/admin-front/src/application/actions/users.js
@@ -35,8 +35,13 @@ export const setAdmin = (userId) => (dispatch) =>
   api
     .post(`users/${userId}/set-admin`, {}, SET_USER_ADMIN, dispatch, { userId })
     .catch((error) => {
+      const errorMessage =
+        error?.response?.error?.message ||
+        error?.response?.message ||
+        error?.message;
+
       if (
-        error?.message ===
+        errorMessage ===
         'Assigning the administrator role to test users is prohibited'
       ) {
         dispatch(addError(new Error('FailSetAdminTestUser')));

--- a/front-core/services/api/index.js
+++ b/front-core/services/api/index.js
@@ -153,8 +153,9 @@ async function createRequest(
     }
 
     if (response.status === 403) {
-      const error = new Error('403 forbidden');
+      const error = new Error(responseBody?.error?.message || '403 forbidden');
       error.details = responseBody?.error?.details;
+      error.response = responseBody;
       throw error;
     }
 


### PR DESCRIPTION
- preserve backend 403 message in API errors for action-level handling

- match nested response error message in setAdmin before dispatching toast