### PR TITLE
fix(notification): harden message delivery and helm auth config

### DIFF
--- a/config-templates/notification/config.json
+++ b/config-templates/notification/config.json
@@ -18,11 +18,11 @@
       "dialect": "postgres"
     },
     "auth_server": {
-      "host": "http://localhost:8080",
-      "user": "AuthorizationBasicLogin",
-      "password": "secretPassword"
+      "host": "http://id-api:8100",
+      "basicAuthToken": "Basic <REDACTED>"
     },
     "smsServer": {
+      "isEnabled": false,
       "url": "https://test.liquio.local/Subscribe/SendSmsQ.php",
       "access_token": ""
     },
@@ -37,6 +37,7 @@
     },
     "sendSmsByNotifyhubAPI": true,
     "smtpServer": {
+      "isEnabled": false,
       "host": "mail.local",
       "secure": false,
       "port": 25,

--- a/front-core/translation/en-GB.js
+++ b/front-core/translation/en-GB.js
@@ -773,6 +773,7 @@ export default {
     AddMock: 'Add Mock',
     NewMock: 'New Mock',
     noMocksDefined: 'No mocks defined',
+    noData: 'No data',
     switchMode: 'Switch mode',
     ClearAll: 'Clear all',
     FiltersNumber: 'You selected {{number}} filters',

--- a/front-core/translation/fr-FR.js
+++ b/front-core/translation/fr-FR.js
@@ -821,6 +821,7 @@ export default {
     AddMock: 'Ajouter un mock',
     NewMock: 'Nouveau mock',
     noMocksDefined: 'Aucun mock défini',
+    noData: 'Aucune donnée',
     switchMode: 'Changer de mode',
     ClearAll: 'Tout effacer',
     FiltersNumber: 'Vous avez sélectionné {{number}} filtres',

--- a/front-core/translation/uk-UA.js
+++ b/front-core/translation/uk-UA.js
@@ -764,6 +764,7 @@ export default {
     AddMock: 'Додати мок',
     NewMock: 'Новий мок',
     noMocksDefined: 'Моки не створені',
+    noData: 'Немає даних',
     switchMode: 'Змінити режим',
     DisplayOptionsInARow: 'Показувати опції в одному рядку',
     Path: 'Шлях',

--- a/helm-chart/templates/core-services/notification.configmap.yaml
+++ b/helm-chart/templates/core-services/notification.configmap.yaml
@@ -25,16 +25,16 @@ metadata:
       "dialect" "postgres"
     )
     "auth_server" (dict
-      "host" "http://localhost:8080"
-      "user" "AuthorizationBasicLogin"
-      "password" "secretPassword"
+      "host" (printf "http://%s-id-api:80" (include "liquio.fullname" .))
+      "basicAuthToken" "Basic <REDACTED>"
     )
     "unisender" (dict
       "api_key" "secretToken"
       "sender_email" "noreply@example.com"
       "hardcode_subject" "New message"
     )
-     "smsServer" (dict
+    "smsServer" (dict
+       "isEnabled" false
        "url" (printf "%s://%s/Subscribe/SendSmsQ.php" (include "liquio.scheme" .) (include "liquio.publicHost" (dict "ctx" . "service" "sms")))
        "access_token" ""
     )
@@ -49,6 +49,7 @@ metadata:
     )
     "sendSmsByNotifyhubAPI" true
     "smtpServer" (dict
+      "isEnabled" false
       "host" "mail.local"
       "secure" false
       "port" 25

--- a/helm-chart/templates/shared/init-secrets.job.yaml
+++ b/helm-chart/templates/shared/init-secrets.job.yaml
@@ -180,7 +180,7 @@ spec:
                 --from-literal=message_queue.json="$MANAGER_MQ_JSON" \
                 --from-literal=system_notifier.json="$MANAGER_SYSTEM_NOTIFIER_JSON"
 
-              NOTIFICATION_CONFIG_JSON="$(jq -cn --arg dbPassword "$POSTGRES_PASSWORD" --arg user "$NOTIFY_LOGIN" --arg notifyPassword "$NOTIFY_PASSWORD" '{production: {password: $dbPassword, db: {password: $dbPassword}, authorization: {list: [{user: $user, password: $notifyPassword}]}}}')"
+              NOTIFICATION_CONFIG_JSON="$(jq -cn --arg dbPassword "$POSTGRES_PASSWORD" --arg user "$NOTIFY_LOGIN" --arg notifyPassword "$NOTIFY_PASSWORD" --arg oauth "$OAUTH_SECRET" '{production: {password: $dbPassword, db: {password: $dbPassword}, authorization: {list: [{user: $user, password: $notifyPassword}]}, auth_server: {basicAuthToken: ("Basic " + $oauth)}}}')"
 
               kubectl create secret generic {{ include "liquio.secretConfig.name" (dict "ctx" . "service" "notification") }} \
                 --namespace "$NAMESPACE" \

--- a/notification/src/controllers/message.js
+++ b/notification/src/controllers/message.js
@@ -423,6 +423,23 @@ const Message = class extends Auth {
     let sendBySmsPromise;
     log.save('send-message-by-user-request', { phones: sendBySms, emails: sendByEmail });
 
+    usersMessages = await UsersMessages.bulkCreate(
+      usersInfo.map((v) => {
+        return {
+          user_id: v.id,
+          message_id: msg.message_id,
+        };
+      }),
+      { returning: true },
+    );
+    usersMessages = usersMessages.map((v) => {
+      return {
+        userMessageId: v.user_message_id,
+        userId: v.user_id,
+        messageId: v.message_id,
+      };
+    });
+
     // Check if need to send by SMS.
     if (this.isValidShortMessageTranslit(body) && this.isValidShortMessage(body) && !not_send) {
       // Check phones prefix in SMS blacklist.
@@ -453,23 +470,6 @@ const Message = class extends Auth {
 
     // Check if need to send by email.
     if (this.isValidFullMessage(body) && this.isValidTitleMessage(body)) {
-      usersMessages = await UsersMessages.bulkCreate(
-        usersInfo.map((v) => {
-          let obj = {
-            user_id: v.id,
-            message_id: msg.message_id,
-          };
-          return obj;
-        }),
-        { returning: true },
-      );
-      usersMessages = usersMessages.map((v) => {
-        return {
-          userMessageId: v.user_message_id,
-          userId: v.user_id,
-          messageId: v.message_id,
-        };
-      });
       if (!not_send) {
         sendByEmailPromise = this.sendByEmails(sendByEmail, body.title_message, body.full_message, undefined, body.template_id, body.attachments);
       }
@@ -1104,7 +1104,12 @@ const Message = class extends Auth {
           readQuantityPromise,
         ]);
       } catch (e) {
-        return res.send(e.statusCode, e);
+        const statusCode = e?.statusCode || e?.response?.status || 500;
+        const error = {
+          message: e?.message || 'Can not get messages.',
+        };
+        log.save('get-messages-error', { statusCode, error }, 'error');
+        return res.send(statusCode, { error });
       }
     } else {
       result = await this.getAllMessages(req.query);

--- a/notification/src/controllers/test.js
+++ b/notification/src/controllers/test.js
@@ -130,7 +130,8 @@ const TestController = class {
       }
       case AUTH_SERVICE_NAME: {
         pingUrl = (conf.pingRoutes.authService || AUTH_SERVICE_PING_URL) + '_with_auth';
-        headers = { Authorization: 'Basic ' + Buffer.from(conf.auth_server.user + ':' + conf.auth_server.password, 'utf8').toString('base64') };
+        const basicAuthToken = conf.auth_server.basicAuthToken || Buffer.from(conf.auth_server.user + ':' + conf.auth_server.password, 'utf8').toString('base64');
+        headers = { Authorization: basicAuthToken.startsWith('Basic ') ? basicAuthToken : 'Basic ' + basicAuthToken };
         break;
       }
       default:

--- a/notification/src/models/authServer.js
+++ b/notification/src/models/authServer.js
@@ -3,13 +3,12 @@ let { conf } = global;
 
 const Auth = class {
   constructor() {
-    if (conf.auth_server.host == 'https://id.test.liquio.local') {
-      conf.auth_server.user = 999;
-      conf.auth_server.password = 999;
-    }
-    this.pass = Buffer(`${conf.auth_server.user}:${conf.auth_server.password}`).toString('base64');
-    // this.getUsersInfo(["588b54786c7749c1b73fa08d","588b67106c7749c1b73fa0a7"]).then((e)=>{console.log(e);})
+    this.basicAuthToken = conf.auth_server.basicAuthToken || Buffer(`${conf.auth_server.user}:${conf.auth_server.password}`).toString('base64');
     this.cache = {}; // { "some-user-id": { "expiredAt": "...", "data": { ... } } }
+  }
+
+  get authorizationHeader() {
+    return this.basicAuthToken.startsWith('Basic ') ? this.basicAuthToken : `Basic ${this.basicAuthToken}`;
   }
 
   async checkToken(token) {
@@ -38,7 +37,7 @@ const Auth = class {
     let users = await axios(`${conf.auth_server.host}/user/info/id`, {
       method: 'POST',
       headers: {
-        Authorization: `Basic ${this.pass}`,
+        Authorization: this.authorizationHeader,
       },
       data: {
         id: array,
@@ -55,7 +54,7 @@ const Auth = class {
     let users = await axios(`${conf.auth_server.host}/user/info/ipn`, {
       method: 'POST',
       headers: {
-        Authorization: `Basic ${this.pass}`,
+        Authorization: this.authorizationHeader,
       },
       data: {
         ipn: array,
@@ -73,7 +72,7 @@ const Auth = class {
       url: `${conf.auth_server.host}/user/info/phone?phone=${phone}`,
       method: 'GET',
       headers: {
-        Authorization: `Basic ${this.pass}`,
+        Authorization: this.authorizationHeader,
       },
     }).then((res) => res.data);
   }
@@ -82,7 +81,7 @@ const Auth = class {
     let users = await axios(`${conf.auth_server.host}/user?offset=${startFrom}&limit=${limit}`, {
       method: 'GET',
       headers: {
-        Authorization: `Basic ${this.pass}`,
+        Authorization: this.authorizationHeader,
       },
     }).then((res) => res.data);
     return users;

--- a/notification/src/models/emailGate/smtpModel.js
+++ b/notification/src/models/emailGate/smtpModel.js
@@ -10,8 +10,22 @@ const phpListModel = class {
     this.senderEmail = this.config.sender_email || '\'noreply\' <noreply@localhost>';
   }
 
+  get isEnabled() {
+    return this.config.isEnabled !== false;
+  }
+
+  getDisabledResult() {
+    return { skipped: true, reason: 'SMTP is disabled in config.' };
+  }
+
   async sendMail(body) {
     const { users, text, subject, sendBy, doNotEscapeEmail, attachments } = body;
+
+    if (!this.isEnabled) {
+      const result = this.getDisabledResult();
+      this.log.save('send-email-skipped', { users, subject, reason: result.reason }, 'info');
+      return { result: Array.isArray(users) ? users.map(() => result) : [] };
+    }
 
     const responsesList = [];
     if (Array.isArray(users)) {
@@ -35,6 +49,12 @@ const phpListModel = class {
 
   async sendOneMail(body) {
     const { sendBy } = body;
+
+    if (!this.isEnabled) {
+      const result = this.getDisabledResult();
+      this.log.save('send-one-email-skipped', { email: body.email, subject: body.subject, reason: result.reason }, 'info');
+      return { result };
+    }
 
     let transport;
     try {

--- a/notification/src/models/smsGate/abstractSmsGate.js
+++ b/notification/src/models/smsGate/abstractSmsGate.js
@@ -7,6 +7,14 @@ const AbstractGate = class {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   }
 
+  get isEnabled() {
+    return !conf.smsServer || conf.smsServer.isEnabled !== false;
+  }
+
+  getDisabledResult(target) {
+    return { skipped: true, reason: 'SMS is disabled in config.', target };
+  }
+
   async sendRequest(object) {
     object.json = true;
     try {
@@ -20,6 +28,12 @@ const AbstractGate = class {
 
   async sendSms(phones, text, _msgid) {
     phones = phones.filter((v) => !!v == true);
+
+    if (!this.isEnabled) {
+      const result = phones.map((phone) => this.getDisabledResult(phone));
+      log.save('send-sms-skipped', { phones, text, reason: 'SMS is disabled in config.' }, 'info');
+      return result;
+    }
 
     phones = phones.map((v) => v.replace(/(\+38)?(38)?(3838)?/, '38'));
     if (phones.length <= 100) {
@@ -81,6 +95,13 @@ const AbstractGate = class {
 
   async sendOneSms(phone, text, _msgid) {
     if (!!phone == false) throw { errorCode: 400, message: 'phone empty' };
+
+    if (!this.isEnabled) {
+      const result = this.getDisabledResult(phone);
+      log.save('send-one-sms-skipped', { phone, text, reason: result.reason }, 'info');
+      return result;
+    }
+
     phone = phone.replace(/(\+38)?(38)?(3838)?/, '38');
     this.options.url = (conf.smsServer && conf.smsServer.url ? conf.smsServer.url : 'https://test.liquio.local') + '/Subscribe/SendSmsQ.php';
     this.options.method = 'POST';

--- a/notification/src/models/smsGate/customGate.js
+++ b/notification/src/models/smsGate/customGate.js
@@ -22,6 +22,12 @@ const CustomGate = class extends AbstractGate {
     // Log.
     console.log('CustomGate - sendSms');
 
+    if (!this.isEnabled) {
+      const result = (phones || []).map((phone) => this.getDisabledResult(phone));
+      log.save('send-sms-skipped', { phones, text, reason: 'SMS is disabled in config.' }, 'info');
+      return result;
+    }
+
     // Define adapter method.
     this.adapter = global.extensions.adapters.sms;
     if (this.adapter) {
@@ -57,6 +63,12 @@ const CustomGate = class extends AbstractGate {
   async sendOneSms(phone, text, msgid) {
     // Log.
     console.log('CustomGate - sendOneSms');
+
+    if (!this.isEnabled) {
+      const result = this.getDisabledResult(phone);
+      log.save('send-one-sms-skipped', { phone, text, reason: result.reason }, 'info');
+      return result;
+    }
 
     // Define adapter method.
     this.adapter = global.extensions.adapters.sms;

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -442,7 +442,8 @@ jq --arg key "$(generate_secret)" \
   echo "$file"
   jq --arg login "$login" \
     --arg password "$password" \
-    '.production.authorization.list = [{ user: $login, password: $password }]' \
+      --arg authToken "Basic $OAUTH_SECRET" \
+      '.production.authorization.list = [{ user: $login, password: $password }] | .production.auth_server.basicAuthToken = $authToken' \
     $file > $file.tmp && mv $file.tmp $file
 
   file="config/admin-api/notifier.json"

--- a/task/src/services/notifier.js
+++ b/task/src/services/notifier.js
@@ -94,21 +94,27 @@ class NotifierService {
       });
       log.save('get-message-list-response', response);
 
+      // Notification may return an empty body for successful requests.
+      // Normalize the payload so callers always receive a consistent structure.
+      const responseResult = Array.isArray(response?.result) ? response.result : [];
+      const responseMeta = response?.meta && typeof response.meta === 'object' ? response.meta : {};
+
       // Append download token to attachments.
-      for (const result of response.result) {
+      for (const result of responseResult) {
         if (result?.meta?.attachments?.length) {
           result.meta.attachments = result.meta.attachments.map(v => ({ ...v, downloadToken: this.downloadToken.generate(v.fileId) }));
         }
       }
 
       const data = {
-        data: response.result,
-        meta: response.meta
+        data: responseResult,
+        meta: responseMeta
       };
 
       return data;
     } catch (error) {
       log.save('get-message-list-error', error.message);
+      return { data: [], meta: {} };
     }
   }
 


### PR DESCRIPTION
- switch notification auth_server to basicAuthToken usage across runtime and init configs

- persist users_messages independently of email transport execution

- skip smtp/sms sends when disabled while preserving inbox message flow

- normalize task notifier getMessages response handling for empty payloads