### PR TITLE
fix(auth): add explicit success flag to password change response flow

### DIFF
--- a/admin-api/src/controllers/auth.js
+++ b/admin-api/src/controllers/auth.js
@@ -359,8 +359,13 @@ class AuthController extends Controller {
 
     // Change password.
     try {
-      await this.authService.changePassword(authUserInfo.email, oldPassword, newPassword);
-      this.responseData(res, { message: 'Password changed successfully.' });
+      const result = await this.authService.changePassword(authUserInfo.email, oldPassword, newPassword);
+
+      if (!result?.success) {
+        return this.responseError(res, result?.error || 'Failed to change password.', 400);
+      }
+
+      this.responseData(res, { success: true, message: result?.message || 'Password changed successfully.' });
     } catch (err) {
       return this.responseError(res, err, 500);
     }

--- a/admin-api/src/services/auth.js
+++ b/admin-api/src/services/auth.js
@@ -26,6 +26,7 @@ const DEFAULT_ROUTES = {
   getUserStat: '/stat',
   setPassword: '/user/password/set',
   createLocalUser: '/user/create_local',
+  changePassword: '/authorise/local/change_password',
 };
 const SEARCH_USERS_LIMIT = 10;
 const ERROR_MESSAGE_TOKENS_NOT_RESPONSED = 'Access or refresh tokens not responsed from auth server.';
@@ -700,16 +701,17 @@ class AuthService {
 
       log.save('change-user-password-request', { ...options, headers: { ...options.headers, Authorization: 'Basic ***' } });
 
-      const { success, error } = await HttpRequest.send(options);
+      const response = await HttpRequest.send(options);
+      const { success, error, message } = response || {};
 
-      if (error) {
-        log.save('change-user-password-error', error);
-        return { success: false, error };
+      if (error || success === false) {
+        log.save('change-user-password-error', error || message || 'Unknown error');
+        return { success: false, error: error || message };
       }
 
-      log.save('change-user-password-response', { success });
+      log.save('change-user-password-response', { success, message });
 
-      return { success };
+      return { success: success !== false, message };
     } catch (error) {
       log.save('change-user-password-error', error.message);
       return { success: false };

--- a/front-core/translation/en-GB.js
+++ b/front-core/translation/en-GB.js
@@ -3320,6 +3320,7 @@ export default {
     PasswordChanged: 'Password changed',
     PasswordNotChanged: 'Password not changed',
     PasswordIncorrect: 'Incorrect password',
+    'Invalid email or password.': 'Invalid email or password.',
     RequiredField: 'Required field',
     InitialLoading: 'Loading LiquioIntel...',
     ChangePasswordFailed: 'Failed to change password'

--- a/front-core/translation/fr-FR.js
+++ b/front-core/translation/fr-FR.js
@@ -3824,6 +3824,7 @@ export default {
     PasswordChanged: 'Mot de passe modifié avec succès',
     PasswordNotChanged: 'Mot de passe non modifié',
     PasswordIncorrect: 'Mot de passe incorrect',
+    'Invalid email or password.': 'Adresse e-mail ou mot de passe invalide.',
     RequiredField: 'Champ obligatoire',
     InitialLoading: 'Chargement de LiquioIntel...',
     ChangePasswordFailed:

--- a/front-core/translation/uk-UA.js
+++ b/front-core/translation/uk-UA.js
@@ -3649,6 +3649,7 @@ export default {
     PasswordChanged: 'Пароль успішно змінено',
     PasswordNotChanged: 'Пароль не змінено',
     PasswordIncorrect: 'Невірний пароль',
+    'Invalid email or password.': 'Невірна електронна адреса або пароль.',
     RequiredField: "Обов'язкове поле",
     InitialLoading: 'Завантаження LiquioIntel...',
     ChangePasswordFailed: 'Помилка зміни паролю. Перевірте введені дані',

--- a/id-api/src/strategies/local.ts
+++ b/id-api/src/strategies/local.ts
@@ -125,7 +125,7 @@ export async function local(app: Express) {
 
     // Validate fields
     if (!email || !oldPassword || !newPassword) {
-      res.status(400).send({ error: 'Invalid request.' });
+      res.status(400).send({ success: false, error: 'Invalid request.' });
       return;
     }
 
@@ -137,14 +137,14 @@ export async function local(app: Express) {
     // Do not try to change password if the number of attempts exceeds the limit until the maxAttemptDelay expires
     if (attemptCounter > passwordManager.maxAttempts) {
       log.save('user-auth-by-local|bruteforce-alert', { email, attemptCounter }, 'info');
-      res.status(429).send({ error: 'Too many attempts. Please try again later.' });
+      res.status(429).send({ success: false, error: 'Too many attempts. Please try again later.' });
       return;
     }
 
     const { strong, reason } = passwordManager.isStrongPassword(newPassword);
     if (!strong) {
       log.save('user-change-password|weak-password', { email, reason }, 'info');
-      res.status(400).send({ error: reason });
+      res.status(400).send({ success: false, error: reason });
       return;
     }
 
@@ -158,28 +158,28 @@ export async function local(app: Express) {
 
       if (!user) {
         log.save('user-change-password|user-not-found', { email }, 'info');
-        res.status(401).send({ error: GENERIC_FAIL_DESCRIPTION });
+        res.status(401).send({ success: false, error: GENERIC_FAIL_DESCRIPTION });
         return;
       }
 
       const localServiceInfo = user.user_services.find((s) => s.provider === 'local');
       if (!localServiceInfo) {
         log.save('user-change-password|user-credentials-not-found', { email }, 'info');
-        res.status(401).send({ error: GENERIC_FAIL_DESCRIPTION });
+        res.status(401).send({ success: false, error: GENERIC_FAIL_DESCRIPTION });
         return;
       }
 
       const currentPasswordHash = (localServiceInfo.data as any)?.password;
       if (!currentPasswordHash) {
         log.save('user-change-password|no-password', { email }, 'info');
-        res.status(401).send({ error: GENERIC_FAIL_DESCRIPTION });
+        res.status(401).send({ success: false, error: GENERIC_FAIL_DESCRIPTION });
         return;
       }
 
       const isPasswordValid = await passwordManager.verifyPassword(oldPassword, currentPasswordHash);
       if (!isPasswordValid) {
         log.save('user-change-password|password-invalid', { email }, 'info');
-        res.status(401).send({ error: GENERIC_FAIL_DESCRIPTION });
+        res.status(401).send({ success: false, error: GENERIC_FAIL_DESCRIPTION });
         return;
       }
 
@@ -187,7 +187,7 @@ export async function local(app: Express) {
       const oldPasswords = [currentPasswordHash].concat((localServiceInfo?.data as any)?.oldPasswords ?? []);
       if (oldPasswords.find((hash) => passwordManager.verifyPasswordSync(newPassword, hash))) {
         log.save('user-change-password|password-reused', { email }, 'info');
-        res.status(400).send({ error: 'Password cannot be the same as the old ones.' });
+        res.status(400).send({ success: false, error: 'Password cannot be the same as the old ones.' });
         return;
       }
 
@@ -215,10 +215,10 @@ export async function local(app: Express) {
 
       log.save('user-change-password|success', { email }, 'info');
 
-      res.send({ success: true });
+      res.send({ success: true, message: 'Password changed successfully.' });
     } catch (error) {
       log.save('user-change-password|error', { error }, 'error');
-      res.status(401).send({ error: GENERIC_FAIL_DESCRIPTION });
+      res.status(401).send({ success: false, error: GENERIC_FAIL_DESCRIPTION });
     }
   }
 


### PR DESCRIPTION
- id-api: include success=true and message in change_password success response
- id-api: add success=false to all error response paths for consistent contract
- admin-api: preserve success flag and message from upstream response
- admin-api: validate success flag before returning success response to client
- front-core: add missing i18n keys for 'Invalid email or password.' error in ChangePassword translations (en-GB, uk-UA, fr-FR)