### PR TITLE
fix: resolve test suite failures and event service messaging

### DIFF
--- a/event/src/lib/message_queue/index.js
+++ b/event/src/lib/message_queue/index.js
@@ -88,6 +88,7 @@ class MessageQueue {
       await this.init();
       this.totalReconnectCount += 1;
       log.save('amqp-successfully-reconnected', { totalReconnectCount: this.totalReconnectCount });
+      global.messageQueue = this;
     }, this.config.retryConnectionTime || RETRY_CONNECTION_TIME);
   }
 

--- a/front-core/components/Editor/EditorDialog.jsx
+++ b/front-core/components/Editor/EditorDialog.jsx
@@ -41,9 +41,11 @@ export const EditorDialog = ({
   const handleChange = useCallback(
     (newValue) => {
       (onChange || setValue)(newValue);
-      setDiffs(diff(defaultValue, newValue) || []);
+      if (handleSave) {
+        setDiffs(diff(defaultValue, newValue) || []);
+      }
     },
-    [defaultValue, onChange]
+    [defaultValue, onChange, handleSave]
   );
 
   const handleValidate = useCallback((newErrors) => {

--- a/notification/src/controllers/templates.js
+++ b/notification/src/controllers/templates.js
@@ -93,6 +93,7 @@ class Template {
         this.log.save('template-create-null-result', { body: req.body }, 'error');
         return res.send(500, { message: 'Failed to create template - no result returned' });
       }
+      this.log.save('template-create-success', { templateId: result.template_id, type: result.type, title: result.title }, 'info');
       res.send(result);
     } catch (e) {
       this.log.save('template-create-error', { error: e.message, body: req.body }, 'error');
@@ -114,12 +115,13 @@ class Template {
     try {
       let result = await Templates.update(
         { ...req.body },
-        { where: { template_id: req.params.template_id }, individualHooks: true },
+        { where: { template_id: req.params.template_id }, individualHooks: true, returning: true },
       );
       if (!result || result.length === 0) {
         this.log.save('template-update-no-rows', { templateId: req.params.template_id, body: req.body }, 'warn');
         return res.send(404, { message: 'Template not found' });
       }
+      this.log.save('template-update-success', { templateId: req.params.template_id, type: result[1][0].type, title: result[1][0].title }, 'info');
       res.send(result);
     } catch (e) {
       this.log.save('template-update-error', { error: e.message, templateId: req.params.template_id }, 'error');

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -65,7 +65,8 @@ test('Demo cannot login to admin panel (8082)', async ({ page }) => {
 
   // Check if there's an authorization error message
   const hasAuthError = pageContent.includes('not authorized') || pageContent.includes('not allowed') || 
-                      pageContent.includes('access denied') || pageContent.includes('forbidden');
+                      pageContent.includes('access denied') || pageContent.includes('forbidden') ||
+                      pageContent.includes('does not have access rights');
   debug(`Page contains authorization error: ${hasAuthError}`);
   expect(hasAuthError).toBe(true);
 

--- a/test/basic-workflow.spec.js
+++ b/test/basic-workflow.spec.js
@@ -63,7 +63,7 @@ test('Authorize with admin and import register/workflow', async ({ page }) => {
 
   {
     log('Importing workflow 1000');
-    await importWorkflow(page, '../examples/workflow-1000.bpmn');
+    await importWorkflow(page, '../examples/workflow-1000.bpmn', false, true);
 
     log('Verifying the imported workflow');
     await page.goto('http://localhost:8082/workflow/1000');

--- a/test/helpers/workflow.js
+++ b/test/helpers/workflow.js
@@ -7,6 +7,7 @@ async function importWorkflow(page, filePath, isTest = false, isOverwrite = fals
 
   debug('importWorkflow: Navigating to workflows page');
   await page.goto(url);
+  await page.waitForLoadState('networkidle');
   debug('importWorkflow: At workflows page');
 
   const fileChooserPromise = page.waitForEvent('filechooser');

--- a/test/message-template.spec.js
+++ b/test/message-template.spec.js
@@ -1,0 +1,135 @@
+const { test, expect } = require('@playwright/test');
+
+const {
+  ensureAtLoginPage,
+  loginWithPersonalKey,
+  setupLogging,
+  log,
+} = require('./helpers');
+
+const HELLO_WORLD_HTML = [
+  '<!DOCTYPE html>',
+  '<html>',
+  '<head>',
+  '  <meta charset="UTF-8">',
+  '  <title>Hello World</title>',
+  '</head>',
+  '<body>',
+  '  <h1>Hello, World!</h1>',
+  '</body>',
+  '</html>',
+].join('\n');
+
+test.describe('Message Template CRUD', () => {
+  test('create a message template with HTML body', async ({ page }) => {
+    await setupLogging(page);
+    page.setDefaultTimeout(10000);
+
+    const templateTitle = `test-${Date.now()}`;
+
+    // 1) Login as admin.
+    log('Navigating to admin panel');
+    await page.goto('http://localhost:8082/');
+    await ensureAtLoginPage(page);
+    log('Logging in as admin with personal key');
+    await loginWithPersonalKey(page, '../config/admin.p12', 'admin');
+    await expect(page).toHaveURL(/^http:\/\/localhost:8082\//);
+
+    // 2) Navigate to Message Templates page.
+    log('Navigating to /workflow/message-templates');
+    await page.goto('http://localhost:8082/workflow/message-templates');
+    await expect(page).toHaveTitle(/Message Templates/i);
+
+    // 3) Open Create Template dialog.
+    log('Clicking Add New');
+    const addNewButton = page.getByRole('button', { name: /Add New/i });
+    await addNewButton.waitFor({ timeout: 5000 });
+    await addNewButton.click();
+
+    const createDialog = page.getByRole('dialog', { name: /Create Template/i });
+    await createDialog.waitFor({ timeout: 5000 });
+    log('Create Template dialog opened');
+
+    // 5) Fill in the Title field.
+    log('Filling in Title');
+    const titleInput = createDialog.getByRole('textbox', { name: /Title/i });
+    await titleInput.fill(templateTitle);
+
+    // 6) Open the Edit HTML editor.
+    log('Clicking Edit HTML');
+    const editHtmlButton = createDialog.getByRole('button', { name: /Edit HTML/i });
+    await editHtmlButton.click();
+
+    // The Edit HTML dialog has no accessible name — locate by its heading text.
+    const htmlDialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole('heading', { name: /Edit HTML/i }),
+    });
+    await htmlDialog.waitFor({ timeout: 10000 });
+    log('Edit HTML dialog opened');
+
+    // 6) Type HTML into the Monaco editor.
+    log('Typing HTML into Monaco editor');
+    await page.locator('.monaco-editor .view-lines').first().click();
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type(HELLO_WORLD_HTML);
+
+    // Verify at least one line rendered in the editor.
+    await expect(page.locator('.monaco-editor .view-line').first()).toBeVisible();
+
+    // 7) Close the HTML editor.
+    log('Closing Edit HTML dialog');
+    const closeEditorButton = htmlDialog.locator('button').last();
+    await closeEditorButton.click();
+    await expect(htmlDialog).toBeHidden({ timeout: 5000 });
+
+    // 9) Save the template.
+    log('Clicking Save');
+    const saveButton = createDialog.getByRole('button', { name: /Save/i });
+    await saveButton.click();
+
+    // 10) Verify dialog closed and row appeared in the table.
+    log('Verifying template row appears in table');
+    await expect(createDialog).toBeHidden({ timeout: 5000 });
+
+    const tableRow = page.locator('table tbody tr').filter({ hasText: templateTitle });
+    await expect(tableRow).toBeVisible({ timeout: 5000 });
+    await expect(tableRow).toContainText('sms');
+    await expect(tableRow).toContainText(templateTitle);
+
+    log('Message template created successfully');
+
+    // 11) Edit the template — update the title.
+    const editedTitle = `${templateTitle}-edited`;
+    log('Editing created template');
+    await tableRow.hover();
+    await tableRow.getByRole('button', { name: /Edit/i }).click();
+
+    const editDialog = page.getByRole('dialog');
+    await editDialog.waitFor({ timeout: 5000 });
+    log('Edit dialog opened');
+
+    const editTitleInput = editDialog.getByRole('textbox', { name: /Title/i });
+    await editTitleInput.fill(editedTitle);
+
+    const editSaveButton = editDialog.getByRole('button', { name: /Save/i });
+    await editSaveButton.click();
+    await expect(editDialog).toBeHidden({ timeout: 5000 });
+
+    const editedRow = page.locator('table tbody tr').filter({ hasText: editedTitle });
+    await expect(editedRow).toBeVisible({ timeout: 5000 });
+    await expect(editedRow).toContainText(editedTitle);
+    log('Template edited successfully');
+
+    // 12) Clean up — delete the edited template.
+    log('Deleting edited template');
+    await editedRow.hover();
+    await editedRow.getByRole('button', { name: /Delete/i }).click();
+    const confirmDialog = page.getByRole('dialog');
+    const confirmOk = confirmDialog.getByRole('button', { name: /Yes|OK|Confirm|Delete/i });
+    if (await confirmOk.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await confirmOk.click();
+    }
+    await expect(editedRow).toBeHidden({ timeout: 5000 });
+    log('Template deleted successfully');
+  });
+});

--- a/test/playwright.config.js
+++ b/test/playwright.config.js
@@ -1,0 +1,7 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  workers: 1,
+  timeout: 60000,
+});

--- a/test/workflow-900001.spec.js
+++ b/test/workflow-900001.spec.js
@@ -138,9 +138,9 @@ test.describe('Workflow 900001 (Attention Notice)', () => {
     await page.waitForLoadState('networkidle');
     log('Service details page loaded');
 
-    log('Waiting for "Elements.noData" message to appear');
-    await page.getByText('Elements.noData').waitFor();
-    await expect(page.getByText('Elements.noData')).toBeVisible();
+    log('Waiting for "No data" message to appear');
+    await page.getByText('No data').waitFor();
+    await expect(page.getByText('No data')).toBeVisible();
     log('✓ Service details verified - no data message found');
 
     // Extract workflowId from URL for use in admin tests


### PR DESCRIPTION
- event service: reinit global.messageQueue after reconnect for workflow completion
- editor dialog: guard diff() call to prevent crash on undefined
- playwright: configure single worker for sequential test execution
- auth test: add missing authorization error variant
- workflow tests: fix DOM detachment and translated text matching
- message template: add end-to-end CRUD test with idempotent cleanup