### PR TITLE
CYB-2063 fix(id-api): block inactive users in auth paths

### DIFF
--- a/id-api/src/middleware/authenticate.ts
+++ b/id-api/src/middleware/authenticate.ts
@@ -128,6 +128,10 @@ export class AuthMiddleware {
         res.locals.oauth = { token };
         const passport = req.session.passport ?? ({} as any);
         const user = await service.getUser({ userId: token.user.id });
+        if (user?.isActive === false) {
+          res.status(403).send({ error: { message: 'User has been blocked.' } });
+          return;
+        }
         req.session.passport = passport;
         appendTraceMeta({ auth: 'authorise', userId: user.userId });
         await saveSession(req, user);
@@ -216,8 +220,23 @@ export class AuthMiddleware {
 
   checkUserAccess() {
     return async (req: Request, res: Response, next: NextFunction) => {
-      const user = req.session?.passport?.user;
-      const { isActive, userId } = user ?? {};
+      let user = req.session?.passport?.user;
+      const userId = user?.userId;
+
+      // Local auth session initially stores a slim profile without isActive.
+      // Refresh user from DB so blocked checks are always based on current state.
+      if (userId && typeof user?.isActive === 'undefined') {
+        const actualUser = await this.service('auth').getUser({ userId });
+        if (actualUser) {
+          user = actualUser as any;
+          const passport = req.session.passport ?? ({} as any);
+          passport.user = actualUser as any;
+          req.session.passport = passport;
+          await saveSession(req);
+        }
+      }
+
+      const { isActive } = user ?? {};
       const loginHistoryData = prepareLoginHistoryData(req, { actionType: 'login' });
 
       if (!this.checkIdentificationType(user)) {

--- a/id-api/src/strategies/x509.ts
+++ b/id-api/src/strategies/x509.ts
@@ -165,8 +165,23 @@ export async function x509(app: Express) {
   };
 
   app.post('/authorise/x509', passport.authenticate('x509', { keepSessionInfo: true }), async (req: Request, res: Response) => {
+    const userId = (req.user as any)?.userId;
+    const actualUser = userId ? await Services.service('auth').getUser({ userId }) : null;
+
+    if (actualUser?.isActive === false) {
+      req.user = actualUser as any;
+
+      const blockedLoginHistoryData = prepareLoginHistoryData(req, { actionType: 'login' });
+      if (blockedLoginHistoryData) {
+        await Models.model('loginHistory').create(blockedLoginHistoryData);
+      }
+
+      res.status(403).send({ error: { message: 'User has been blocked.' } });
+      return;
+    }
+
     log.save('x509-strategy|authorise|success', { user: Helpers.shorten(JSON.stringify(req.user)) }, 'info');
-    await saveSession(req, req.user);
+    await saveSession(req, actualUser || req.user);
 
     const loginHistoryData = prepareLoginHistoryData(req, { actionType: 'login' });
     if (loginHistoryData) {

--- a/id-api/test/auth-local.e2e.spec.ts
+++ b/id-api/test/auth-local.e2e.spec.ts
@@ -33,6 +33,8 @@ describe('AuthController - local', () => {
   describe('User/password Authorization (local)', () => {
     const email = 'valid@email';
     const password = 'V4l!dPassW0rd';
+    const blockedEmail = 'blocked@email';
+    const blockedPassword = 'Bl0ckedPass!';
     let cookies: any;
     let userId: string;
 
@@ -109,6 +111,51 @@ describe('AuthController - local', () => {
       });
     });
 
+    it('should reject blocked user on /auth', async () => {
+      const blockedUser = await app
+        .model('user')
+        .create(
+          {
+            ipn: '#9999999999',
+            provider: 'local',
+            email: blockedEmail,
+            isActive: false,
+          },
+          { returning: true },
+        )
+        .then((row) => row.dataValues);
+
+      await app.model('userServices').create({
+        provider: 'local',
+        provider_id: blockedEmail,
+        userId: blockedUser.userId,
+        data: {
+          password: bcrypt.hashSync(blockedPassword, 1).toString(),
+          oldPasswords: [],
+        },
+      });
+
+      let blockedCookies: any;
+      await app
+        .request()
+        .post('/authorise/local')
+        .send({ email: blockedEmail, password: blockedPassword })
+        .expect(200)
+        .expect(({ headers }) => {
+          blockedCookies = headers['set-cookie'];
+          expect(blockedCookies).toBeDefined();
+        });
+
+      await app
+        .request()
+        .get('/auth')
+        .set('Cookie', blockedCookies)
+        .expect(403)
+        .expect(({ body }) => {
+          expect(body).toEqual({ error: { message: 'User has been blocked.' } });
+        });
+    });
+
     it('should be able to change password', async () => {
       await app
         .request()
@@ -116,7 +163,7 @@ describe('AuthController - local', () => {
         .send({ email, oldPassword: password, newPassword: 'NewP4ssw0!rd' })
         .expect(200)
         .expect(({ body }) => {
-          expect(body).toEqual({ success: true });
+          expect(body).toEqual({ success: true, message: 'Password changed successfully.' });
         });
 
       const user = await app
@@ -153,6 +200,7 @@ describe('AuthController - local', () => {
         .expect(401)
         .expect(({ body }) => {
           expect(body).toEqual({
+            success: false,
             error: 'Invalid email or password.',
           });
         });
@@ -166,6 +214,7 @@ describe('AuthController - local', () => {
         .expect(400)
         .expect(({ body }) => {
           expect(body).toEqual({
+            success: false,
             error: 'Password must be at least 8 characters long.',
           });
         });

--- a/id-api/test/auth-x509.e2e.spec.ts
+++ b/id-api/test/auth-x509.e2e.spec.ts
@@ -94,5 +94,66 @@ describe('AuthController - x509', () => {
           expect(res.body.redirect).toBe('/authorise/continue/');
         });
     });
+
+    it('should reject blocked user with valid x509 certificate', async () => {
+      await app.model('user').update(
+        {
+          isActive: false,
+        },
+        { where: { ipn: '1234567890' } },
+      );
+
+      nock('http://sign-tool')
+        .post('/x509/signature-info')
+        .once()
+        .reply(200, {
+          subject: {
+            commonName: 'Blocked User',
+            organizationName: 'Liquio Test',
+            countryName: 'UA',
+            serialNumber: '1234567890',
+          },
+          issuer: {
+            commonName: 'Liquio Test CA',
+            organizationName: 'Liquio Test CA',
+            countryName: 'UA',
+          },
+          serial: '1C07D16DDAE3ECF9A031DC7F5257AD25EE541683',
+          signTime: '',
+          content:
+            'ew0KICAidXNlciI6ICJibG9ja2VkdXNlciIsDQogICJlbWFpbCI6ICJibG9ja2VkQGV4YW1wbGUuY29tIiwNCiAgInRpbWVzdGFtcCI6ICIyMDI0LTA3LTE3VDE5OjAwOjAwWiINCn0g',
+          pem:
+            '-----BEGIN CERTIFICATE-----\n' +
+            'MIIDYDCCAkigAwIBAgIUHAfRbdrj7PmgMdx/UletJe5UFoMwDQYJKoZIhvcNAQEL\n' +
+            'BQAwPzELMAkGA1UEBhMCVUExFzAVBgNVBAoMDkxpcXVpbyBUZXN0IENBMRcwFQYD\n' +
+            'VQQDDA5MaXF1aW8gVGVzdCBDQTAeFw0yNTA3MTgxMDE3MDVaFw0yNjA3MTgxMDE3\n' +
+            'MDVaMDkxCzAJBgNVBAYTAlVBMRQwEgYDVQQKDAtMaXF1aW8gVGVzdDEUMBIGA1UE\n' +
+            'AwwLVGVzdCBQZXJzb24wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCP\n' +
+            'FXgHjEagXlO1dJjWMr5a+qsGrB9Y2O+xOd2oiJj0fHb8n0i9Tb8oJpZybGDsFLQ3\n' +
+            'byVjl+jTh+J1BK5x2VkaXbvrHyMpbqJ8yjAayID+q3nETTqBBlMBhJno2Bk+vrhd\n' +
+            '/Hijr1T67qYeoYFIFA8JMBalQQWE0E0e0gJjG4kn0o7ujIEzBqXDVVUwTX6H5iZW\n' +
+            'sRV83hRiHHC+GWsBXxKlIekMpu7WISD3DFNYM/u4zYrZHLoAIuC6EQ8rEhLPZjA6\n' +
+            'of45ehTNlSrSjUPMLzYBtlXPBpJVskmvraf4K/TziRYCz1+SVcmBQcgThOc1Q++o\n' +
+            'u5rIZ3BkphBozTIdGH/hAgMBAAGjWjBYMAkGA1UdEwQCMAAwCwYDVR0PBAQDAgWg\n' +
+            'MB0GA1UdDgQWBBQkP6jBkVCx9CWtGV0eoQkuD3j47jAfBgNVHSMEGDAWgBSBz8K7\n' +
+            '0XPT2o1D66btkNEUAgFrjjANBgkqhkiG9w0BAQsFAAOCAQEAUmbnNL8iJ3cgjW1/\n' +
+            'pLzjVD/KEUkl3Bue89qaN+7VUVrRvAC3aFJKnWGdN2zLH2Q4U6BEPeIuQ8ngKTCS\n' +
+            'jaT4Cg3mJNcNzd8H46Nwck6kM6w1yOsBnfYK89+ZFVEr7X2ml8kRFCVlQPylcCqI\n' +
+            'Ft0MlGgbnMf1jJCvYIO+9ilGvzM8gYkbDN6ST4QMcnvfw2xiJa5yWU24BtqxMfo1\n' +
+            '+IFaQUy45wfuzaz0YYENjjR0oP4sRdv1k1B/xT/azVoyyS0RWxEQpQoC66/XCef0\n' +
+            '59tRa7XoefAbH6d+29ILCqZCjTbeE48wUFfADtlUeXBZRpvvEC79KCVT/Sa+QCEA\n' +
+            'BMQu2w==\n' +
+            '-----END CERTIFICATE-----',
+        });
+
+      await app
+        .request()
+        .post('/authorise/x509')
+        .send({ pkcs7: 'valid' })
+        .expect(403)
+        .expect((res) => {
+          expect(res.body).toEqual({ error: { message: 'User has been blocked.' } });
+        });
+    });
   });
 });

--- a/id-api/test/user.e2e.spec.ts
+++ b/id-api/test/user.e2e.spec.ts
@@ -1,4 +1,5 @@
 import bcrypt from 'bcrypt';
+import crypto from 'crypto';
 
 import { UserAttributes } from '../src/models';
 import { TestApp, config } from './test_app';
@@ -65,6 +66,36 @@ describe('AuthController', () => {
   });
 
   describe('Admin methods', () => {
+    it('should reject blocked user on /user/info', async () => {
+      const randomUuid = crypto.randomUUID();
+      const accessToken = `${randomUuid.slice(0, 14)}1${randomUuid.slice(15)}`;
+      const expires = new Date(Date.now() + 60 * 60 * 1000);
+      const client = await app.model('client').findOne().then((row) => row?.dataValues as any);
+
+      await app.model('user').update({ isActive: false }, { where: { userId: users.local1!.userId } });
+
+      await app.model('accessToken').create({
+        accessToken,
+        clientId: client.clientId,
+        expires,
+        userId: users.local1!.userId,
+        scope: ['userId', 'email', 'isActive'],
+      } as any);
+
+      await app
+        .request()
+        .get('/user/info')
+        .query({ access_token: accessToken })
+        .expect(403)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            error: { message: 'User has been blocked.' },
+          });
+        });
+
+      await app.model('user').update({ isActive: true }, { where: { userId: users.local1!.userId } });
+    });
+
     it('should fail to check if user email is already registered without an email parameter', async () => {
       await app
         .request()


### PR DESCRIPTION
- enforce blocked-user denial in oauth authorise and x509 route

- refresh slim local session user data before /auth access checks

- add e2e coverage for /auth, /user/info, and x509 blocked cases