### PR TITLE
chore(cabinet-front): remove redundant elemets from the left sidebar

### DIFF
--- a/cabinet-front/src/application/modules/inbox/index.jsx
+++ b/cabinet-front/src/application/modules/inbox/index.jsx
@@ -23,13 +23,13 @@ export default {
     }
   ],
   navigation: [
-    {
-      priority: 19,
-      Component: InboxNavigation,
-      access: {
-        isUnitedUser: false,
-        unitHasAccessTo: 'navigation.inbox.InboxFilesListPage'
-      }
-    }
+    // {
+    //   priority: 19,
+    //   Component: InboxNavigation,
+    //   access: {
+    //     isUnitedUser: false,
+    //     unitHasAccessTo: 'navigation.inbox.InboxFilesListPage'
+    //   }
+    // }
   ]
 };

--- a/cabinet-front/src/application/modules/messages/index.jsx
+++ b/cabinet-front/src/application/modules/messages/index.jsx
@@ -29,10 +29,10 @@ export default function getMessagesModule() {
       }
     ],
     navigation: [
-      {
-        priority: 50,
-        Component: MessagesNavigation
-      }
+      // {
+      //   priority: 50,
+      //   Component: MessagesNavigation
+      // }
     ]
   };
 }

--- a/cabinet-front/src/application/modules/registry/index.jsx
+++ b/cabinet-front/src/application/modules/registry/index.jsx
@@ -12,12 +12,12 @@ export default {
     }
   ],
   navigation: [
-    {
-      id: 'Registry',
-      priority: 15,
-      icon: <StorageOutlinedIcon />,
-      path: '/registry',
-      access: { unitHasAccessTo: 'navigation.registry.RegistryPage' }
-    }
+    // {
+    //   id: 'Registry',
+    //   priority: 15,
+    //   icon: <StorageOutlinedIcon />,
+    //   path: '/registry',
+    //   access: { unitHasAccessTo: 'navigation.registry.RegistryPage' }
+    // }
   ]
 };

--- a/cabinet-front/src/application/modules/users/index.js
+++ b/cabinet-front/src/application/modules/users/index.js
@@ -19,12 +19,12 @@ export default {
     }
   ],
   navigation: [
-    {
-      id: 'Users',
-      path: '/users',
-      icon: <AccessibilityNewOutlinedIcon />,
-      priority: 30,
-      access
-    }
+    // {
+    //   id: 'Users',
+    //   path: '/users',
+    //   icon: <AccessibilityNewOutlinedIcon />,
+    //   priority: 30,
+    //   access
+    // }
   ]
 };

--- a/cabinet-front/src/application/modules/workflow/index.js
+++ b/cabinet-front/src/application/modules/workflow/index.js
@@ -83,47 +83,47 @@ export default {
     }
   ],
   navigation: [
-    {
-      id: 'Workflow',
-      icon: <DoneAllIcon />,
-      priority: 30,
-      access: {
-        isUnitedUser: false,
-        unitHasAccessTo: [
-          'navigation.workflow.MyWorkflow',
-          'navigation.workflow.Drafts',
-          'navigation.workflow.Trash'
-        ]
-      },
-      children: [
-        {
-          id: 'MyWorkflow',
-          path: '/workflow',
-          uiFilter: 'workflows.not-draft',
-          access: {
-            isUnitedUser: false,
-            unitHasAccessTo: 'navigation.workflow.MyWorkflow'
-          }
-        },
-        {
-          id: 'Drafts',
-          path: '/workflow/drafts',
-          uiFilter: 'workflows.draft',
-          access: {
-            isUnitedUser: false,
-            unitHasAccessTo: 'navigation.workflow.Drafts'
-          }
-        },
-        {
-          id: 'Trash',
-          path: '/workflow/trash',
-          uiFilter: 'workflows.trash',
-          access: {
-            isUnitedUser: false,
-            unitHasAccessTo: 'navigation.workflow.Trash'
-          }
-        }
-      ]
-    }
+    // {
+    //   id: 'Workflow',
+    //   icon: <DoneAllIcon />,
+    //   priority: 30,
+    //   access: {
+    //     isUnitedUser: false,
+    //     unitHasAccessTo: [
+    //       'navigation.workflow.MyWorkflow',
+    //       'navigation.workflow.Drafts',
+    //       'navigation.workflow.Trash'
+    //     ]
+    //   },
+    //   children: [
+    //     {
+    //       id: 'MyWorkflow',
+    //       path: '/workflow',
+    //       uiFilter: 'workflows.not-draft',
+    //       access: {
+    //         isUnitedUser: false,
+    //         unitHasAccessTo: 'navigation.workflow.MyWorkflow'
+    //       }
+    //     },
+    //     {
+    //       id: 'Drafts',
+    //       path: '/workflow/drafts',
+    //       uiFilter: 'workflows.draft',
+    //       access: {
+    //         isUnitedUser: false,
+    //         unitHasAccessTo: 'navigation.workflow.Drafts'
+    //       }
+    //     },
+    //     {
+    //       id: 'Trash',
+    //       path: '/workflow/trash',
+    //       uiFilter: 'workflows.trash',
+    //       access: {
+    //         isUnitedUser: false,
+    //         unitHasAccessTo: 'navigation.workflow.Trash'
+    //       }
+    //     }
+    //   ]
+    // }
   ]
 };

--- a/front-core/layouts/components/Navigator/index.jsx
+++ b/front-core/layouts/components/Navigator/index.jsx
@@ -267,7 +267,7 @@ const Navigator = (props) => {
 
   return (
     <>
-      {checkAccess({
+      {/* {checkAccess({
         access: {
           isUnitedUser: false,
           unitHasAccessTo: 'navigation.tasks.CreateTaskButton'
@@ -276,7 +276,9 @@ const Navigator = (props) => {
         <CreateTaskButton isSidebar={true} />
       ) : (
         <div className={classes.emptyCreateButton} />
-      )}
+      )}*/}
+
+      <div className={classes.emptyCreateButton} />
 
       {isMobile ? (
         <div className={classes.verticalScroll}>{contentWithoutScroll()}</div>


### PR DESCRIPTION
## Summary of Changes

> [!IMPORTANT]
> The fix is done in a hard-code way, so it should be removed immediately after migration to the new menu elements setup is completed.

- removed redundant elements from the left sidebar
