### PR TITLE
feat(plugin-installer): emit structured JSON logs matching component …

### DIFF
--- a/components/external-reader/package.json
+++ b/components/external-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liquio-external-reader",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "engines": {
     "node": "22"
   },

--- a/components/external-reader/src/components/providers/providers.service.ts
+++ b/components/external-reader/src/components/providers/providers.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 
-import { Log } from '@liquio/back-core';
-import { PluginLoader, PluginRegistry } from '@liquio/plugin-sdk';
+import { PluginLoader, PluginLogger, PluginRegistry } from '@liquio/plugin-sdk';
 
 import { ConfigurationService } from '@components/configuration/configuration.service';
 import { Configuration } from '@components/configuration/configuration.types';
@@ -31,10 +30,16 @@ export class ProvidersService implements OnModuleInit {
   async onModuleInit() {
     const pluginsConfig = this.config.get('plugins');
     if (pluginsConfig) {
-      // `LoggerService` is a NestJS `ConsoleLogger`, not a `@liquio/back-core` `Log` instance
-      // (their APIs are unrelated), so `PluginLoader` gets its own standalone `Log` instance
-      // rather than the injected logger.
-      this.pluginRegistry = await new PluginLoader(new Log()).load(pluginsConfig);
+      // Adapt the injected NestJS `LoggerService` to the minimal `PluginLogger` contract
+      const logger = this.logger;
+      const pluginLog: PluginLogger = {
+        save: (type: string, data?: unknown, level?: string) => {
+          if (level === 'error') return logger.error(type, data);
+          if (level === 'warning') return logger.warn(type, data);
+          return logger.log(type, data);
+        },
+      };
+      this.pluginRegistry = await new PluginLoader(pluginLog).load(pluginsConfig);
     }
     this.loadServices();
   }

--- a/packages/plugin-installer/package-lock.json
+++ b/packages/plugin-installer/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
-        "multiconf": "^4.0.0"
+        "@liquio/back-core": "^0.1.0",
+        "multiconf": "^4.2.1"
       },
       "bin": {
         "liquio-plugin-installer": "dist/cli.js"
@@ -1223,6 +1224,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@liquio/back-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@liquio/back-core/-/back-core-0.1.0.tgz",
+      "integrity": "sha512-pCyrwP706HIQKLGoIrZNn7GhwNEojOUajtXz8nFfDM12o7iG3bnzYl3lv/9cf3niz/JMX1n2RdJ8tnNFliugwQ==",
+      "license": "SEE LICENSE IN ../../LICENSE.md"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.0",

--- a/packages/plugin-installer/package.json
+++ b/packages/plugin-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquio/plugin-installer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "description": "Installs Liquio plugin npm packages listed in a component's plugins.json into a shared volume",
   "main": "dist/index.js",
@@ -27,7 +27,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "multiconf": "^4.0.0"
+    "@liquio/back-core": "^0.1.0",
+    "multiconf": "^4.2.1"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/packages/plugin-installer/src/cli.ts
+++ b/packages/plugin-installer/src/cli.ts
@@ -2,11 +2,14 @@
 import fs from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import Multiconf from 'multiconf';
+import { ConsoleLogProvider, Log } from '@liquio/back-core';
 import { installPlugins } from './install';
 
 const configDir = process.env.CONFIG_PATH || '/var/www/config';
 const secretPath = process.env.SECRET_PATH;
 const envConfigPrefix = process.env.LIQUIO_CONFIG_PREFIX || 'LIQUIO_CFG_PLUGIN_INSTALLER_';
+
+const log = new Log([new ConsoleLogProvider('console')], ['console']);
 
 installPlugins(
   {
@@ -21,9 +24,9 @@ installPlugins(
     mkdirSync: (p) => fs.mkdirSync(p, { recursive: true }),
     writeFileSync: fs.writeFileSync,
     execFileSync,
-    log: console.log,
+    log: log.save.bind(log),
   },
 ).catch((err) => {
-  console.error(err);
+  log.save('plugin-installer-error', { message: err.message, error: err }, 'error');
   process.exit(1);
 });

--- a/packages/plugin-installer/src/install.spec.ts
+++ b/packages/plugin-installer/src/install.spec.ts
@@ -25,7 +25,7 @@ describe('installPlugins', () => {
 
     await installPlugins(options, deps);
 
-    expect(deps.log).toHaveBeenCalledWith(`[plugin-installer] No config directory at ${options.configDir}, nothing to install.`);
+    expect(deps.log).toHaveBeenCalledWith('plugin-installer-no-config-dir', { configDir: options.configDir });
     expect(deps.loadConfig).not.toHaveBeenCalled();
     expect(deps.execFileSync).not.toHaveBeenCalled();
   });
@@ -35,7 +35,7 @@ describe('installPlugins', () => {
 
     await installPlugins(options, deps);
 
-    expect(deps.log).toHaveBeenCalledWith(`[plugin-installer] No plugins.json in ${options.configDir}, nothing to install.`);
+    expect(deps.log).toHaveBeenCalledWith('plugin-installer-no-plugins-config', { configDir: options.configDir });
     expect(deps.execFileSync).not.toHaveBeenCalled();
   });
 
@@ -48,7 +48,7 @@ describe('installPlugins', () => {
 
     await installPlugins(options, deps);
 
-    expect(deps.log).toHaveBeenCalledWith('[plugin-installer] No enabled plugins in plugins.json, nothing to install.');
+    expect(deps.log).toHaveBeenCalledWith('plugin-installer-no-enabled-plugins');
     expect(deps.execFileSync).not.toHaveBeenCalled();
   });
 
@@ -59,7 +59,7 @@ describe('installPlugins', () => {
 
     await installPlugins(options, deps);
 
-    expect(deps.log).toHaveBeenCalledWith('[plugin-installer] No enabled plugins in plugins.json, nothing to install.');
+    expect(deps.log).toHaveBeenCalledWith('plugin-installer-no-enabled-plugins');
     expect(deps.execFileSync).not.toHaveBeenCalled();
   });
 

--- a/packages/plugin-installer/src/install.ts
+++ b/packages/plugin-installer/src/install.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { Log } from '@liquio/back-core';
 
 export interface InstallOptions {
   configDir: string;
@@ -13,12 +14,12 @@ export interface InstallDependencies {
   mkdirSync: (p: string) => void;
   writeFileSync: (p: string, contents: string) => void;
   execFileSync: (cmd: string, args: string[], opts: { cwd: string; stdio: 'inherit' }) => void;
-  log: (message: string) => void;
+  log: Log['save'];
 }
 
 export async function installPlugins(options: InstallOptions, deps: InstallDependencies): Promise<void> {
   if (!deps.existsSync(options.configDir)) {
-    deps.log(`[plugin-installer] No config directory at ${options.configDir}, nothing to install.`);
+    deps.log('plugin-installer-no-config-dir', { configDir: options.configDir });
     return;
   }
 
@@ -26,14 +27,14 @@ export async function installPlugins(options: InstallOptions, deps: InstallDepen
   const pluginsConfig = config.plugins as { plugins?: { package: string; version: string; isEnabled: boolean }[] } | undefined;
 
   if (!pluginsConfig) {
-    deps.log(`[plugin-installer] No plugins.json in ${options.configDir}, nothing to install.`);
+    deps.log('plugin-installer-no-plugins-config', { configDir: options.configDir });
     return;
   }
 
   const plugins = (pluginsConfig.plugins || []).filter((p) => p.isEnabled);
 
   if (plugins.length === 0) {
-    deps.log('[plugin-installer] No enabled plugins in plugins.json, nothing to install.');
+    deps.log('plugin-installer-no-enabled-plugins');
     return;
   }
 
@@ -44,12 +45,12 @@ export async function installPlugins(options: InstallOptions, deps: InstallDepen
   );
 
   const specs = plugins.map((p) => `${p.package}@${p.version}`);
-  deps.log(`[plugin-installer] Installing: ${specs.join(', ')}`);
+  deps.log('plugin-installer-installing', { plugins: specs });
 
   deps.execFileSync('npm', ['install', '--omit=dev', '--registry', options.registry, ...specs], {
     cwd: options.installDir,
     stdio: 'inherit',
   });
 
-  deps.log('[plugin-installer] Done.');
+  deps.log('plugin-installer-done', { plugins: specs });
 }

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquio/plugin-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "description": "Provider/plugin interfaces and runtime loader shared by Liquio backend components",
   "main": "dist/index.js",
@@ -21,9 +21,6 @@
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "test": "jest"
-  },
-  "dependencies": {
-    "@liquio/back-core": "^0.1.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./logger";
 export * from "./manifest/plugin_manifest";
 export * from "./providers/base_provider";
 export * from "./providers/event_external_service_provider";

--- a/packages/plugin-sdk/src/loader/plugin_loader.spec.ts
+++ b/packages/plugin-sdk/src/loader/plugin_loader.spec.ts
@@ -64,7 +64,14 @@ describe("PluginLoader", () => {
 
     expect(registry.has("some-plugin")).toBe(true);
     expect(registry.get("some-plugin")).toBeInstanceOf(WorkingPlugin);
-    expect(log.save).not.toHaveBeenCalled();
+    expect(log.save).toHaveBeenCalledWith(
+      "plugin-load-success",
+      { name: "some-plugin", package: "some-plugin-package" },
+    );
+    expect(log.save).toHaveBeenCalledWith(
+      "plugin-load-summary",
+      { configured: 1, loaded: 1, plugins: ["some-plugin"] },
+    );
   });
 
   it("skips a disabled entry without calling requirePackageJson", async () => {
@@ -80,7 +87,10 @@ describe("PluginLoader", () => {
     expect(deps.requirePackageJson).not.toHaveBeenCalled();
     expect(deps.requireModule).not.toHaveBeenCalled();
     expect(registry.has("some-plugin")).toBe(false);
-    expect(log.save).not.toHaveBeenCalled();
+    expect(log.save).toHaveBeenCalledWith(
+      "plugin-load-summary",
+      { configured: 0, loaded: 0, plugins: [] },
+    );
   });
 
   it("degrades gracefully when the manifest is missing/invalid", async () => {
@@ -97,7 +107,16 @@ describe("PluginLoader", () => {
     const registry = await loader.load(makeConfig());
 
     expect(registry.has("some-plugin")).toBe(false);
-    expect(log.save).toHaveBeenCalledTimes(1);
+    expect(log.save).toHaveBeenCalledWith(
+      "plugin-load-error",
+      expect.objectContaining({ message: expect.any(String) }),
+      "error",
+    );
+    expect(log.save).toHaveBeenCalledWith(
+      "plugin-load-summary",
+      { configured: 1, loaded: 0, plugins: [] },
+    );
+    expect(log.save).toHaveBeenCalledTimes(2);
   });
 
   it("degrades gracefully when the plugin constructor throws", async () => {
@@ -113,7 +132,7 @@ describe("PluginLoader", () => {
     const registry = await loader.load(makeConfig());
 
     expect(registry.has("some-plugin")).toBe(false);
-    expect(log.save).toHaveBeenCalledTimes(1);
+    expect(log.save).toHaveBeenCalledTimes(2);
   });
 
   it("loads the fine entry and skips the broken one when both are present", async () => {
@@ -152,6 +171,10 @@ describe("PluginLoader", () => {
     expect(registry.has("broken-plugin")).toBe(false);
     expect(registry.has("fine-plugin")).toBe(true);
     expect(registry.get("fine-plugin")).toBeInstanceOf(WorkingPlugin);
-    expect(log.save).toHaveBeenCalledTimes(1);
+    expect(log.save).toHaveBeenCalledWith(
+      "plugin-load-summary",
+      { configured: 2, loaded: 1, plugins: ["fine-plugin"] },
+    );
+    expect(log.save).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/plugin-sdk/src/loader/plugin_loader.ts
+++ b/packages/plugin-sdk/src/loader/plugin_loader.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { Log } from "@liquio/back-core";
+import { PluginLogger } from "../logger";
 import {
   readPluginManifest,
   assertManifestCompatible,
@@ -33,16 +33,21 @@ const defaultDeps: PluginLoadDependencies = {
 
 export class PluginLoader {
   constructor(
-    private readonly log: Log,
+    private readonly log: PluginLogger,
     private readonly deps: PluginLoadDependencies = defaultDeps,
   ) {}
 
   async load(config: PluginsConfig): Promise<PluginRegistry> {
     const registry = new PluginRegistry();
-    for (const entry of config.plugins) {
-      if (!entry.isEnabled) continue;
+    const enabled = config.plugins.filter((entry) => entry.isEnabled);
+    for (const entry of enabled) {
       await this.loadOne(registry, config.pluginsDir, entry);
     }
+    this.log.save("plugin-load-summary", {
+      configured: enabled.length,
+      loaded: registry.all().size,
+      plugins: [...registry.all().keys()],
+    });
     return registry;
   }
 
@@ -63,6 +68,7 @@ export class PluginLoader {
       const instance = new PluginClass(context, entry.options ?? {});
       await instance.onInit();
       registry.register(entry.name, instance);
+      this.log.save("plugin-load-success", { name: entry.name, package: entry.package });
     } catch (err) {
       const loadError = new PluginLoadError(
         entry.name,

--- a/packages/plugin-sdk/src/logger.ts
+++ b/packages/plugin-sdk/src/logger.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimal logging contract plugins and the loader depend on.
+ */
+export interface PluginLogger {
+  save(type: string, data?: unknown, level?: string): unknown;
+}

--- a/packages/plugin-sdk/src/providers/base_provider.ts
+++ b/packages/plugin-sdk/src/providers/base_provider.ts
@@ -1,7 +1,7 @@
-import { Log } from "@liquio/back-core";
+import { PluginLogger } from "../logger";
 
 export interface PluginContext {
-  log: Log;
+  log: PluginLogger;
   pluginConfig: Record<string, unknown>;
 }
 


### PR DESCRIPTION
…output

- plugin-installer now logs via @liquio/back-core's Log/ConsoleLogProvider instead of plain console.log, matching task/event/external-reader's log format
- PluginLoader logs a plugin-load-success event per loaded plugin and a plugin-load-summary after each load() call, so startup shows whether plugins actually loaded, not just failures
- decouple plugin-sdk from @liquio/back-core's concrete Log class via a minimal PluginLogger interface, so any structured logger can be used
- external-reader's ProvidersService now feeds plugin-loader logs through its own NestJS LoggerService instead of a standalone, provider-less Log instance that was silently dropping plugin-load-error logs