### PR TITLE
style: fix eslint/prettier violations flagged by CI

### DIFF
--- a/components/admin-api/src/validators/cabinet_menu.ts
+++ b/components/admin-api/src/validators/cabinet_menu.ts
@@ -3,8 +3,7 @@ import { checkSchema } from 'express-validator';
 import { ValidationConfig, Validator } from './validator';
 
 const isNullableUuid = (value) =>
-  value === null ||
-  (typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value));
+  value === null || (typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value));
 
 const isNullableString = (value) => value === null || typeof value === 'string';
 const isPlainObject = (value) => typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/components/register/tests/fixtures/index.ts
+++ b/components/register/tests/fixtures/index.ts
@@ -10,7 +10,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Register for records.e2e.spec.ts
     200: {
@@ -22,7 +22,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Register for registers.e2e.spec.ts
     300: {
@@ -34,7 +34,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Register for afterhandler-blockchain.e2e.spec.ts
     400: {
@@ -46,7 +46,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Register for afterhandler-elastic.e2e.spec.ts
     500: {
@@ -58,7 +58,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Register for afterhandler-plink.e2e.spec.ts
     600: {
@@ -70,7 +70,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Register for afterhandler-webhook.e2e.spec.ts
     700: {
@@ -82,7 +82,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Register for encryption.e2e.spec.ts
     800: {
@@ -94,7 +94,7 @@ export async function insertData(sequelize) {
       created_by: 'test-user',
       updated_by: 'test-user',
       created_at: '2023-01-01T00:00:00.000Z',
-      updated_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z'
     },
     // Legacy register (kept for backward compatibility if needed)
     90: {
@@ -106,8 +106,8 @@ export async function insertData(sequelize) {
       created_by: 'diia-stage',
       updated_by: 'diia-stage',
       created_at: '2022-01-24T09:00:44.385Z',
-      updated_at: '2024-05-13T10:34:25.070Z',
-    },
+      updated_at: '2024-05-13T10:34:25.070Z'
+    }
   };
 
   // Registers
@@ -126,10 +126,10 @@ export async function insertData(sequelize) {
           register.created_by,
           register.updated_by,
           register.created_at,
-          register.updated_at,
-        ],
+          register.updated_at
+        ]
       },
-      { raw: true },
+      { raw: true }
     );
   }
 
@@ -152,7 +152,7 @@ export async function insertData(sequelize) {
         "(record) => {\n    const casesIndicatorsMap = {\n        case8: '8',\n        case13: '13',\n        case14: '14',\n        case15: '15',\n        case16: '16',\n        case18: '18',\n        case27: '27'\n    };\n    const casesIndicators = '|' + Object.entries(casesIndicatorsMap).map(v => record.data[v[0]] ? v[1] : null).filter(v => !!v).join('|') + '|';\n    return [record.data.atuId, record.data.OBJ_ID, casesIndicators];\n};",
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     151: {
       id: 151,
@@ -171,15 +171,14 @@ export async function insertData(sequelize) {
       to_search_string: '(record) => { return [record.data.RET_ID]; };',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     163: {
       id: 163,
       register_id: 90,
       name: 'ATU_NAMES',
       description: 'ATU_NAMES',
-      schema:
-        '{"type":"object","properties":{"AN_ID":{"type":"string","public":true},"NAME":{"type":"string","public":true}},"required":[]}',
+      schema: '{"type":"object","properties":{"AN_ID":{"type":"string","public":true},"NAME":{"type":"string","public":true}},"required":[]}',
       parent_id: null,
       meta: '{"isTest":false}',
       created_by: 'diia-stage',
@@ -190,7 +189,7 @@ export async function insertData(sequelize) {
       to_search_string: '() => "";',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     164: {
       id: 164,
@@ -209,7 +208,7 @@ export async function insertData(sequelize) {
       to_search_string: '() => "";',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     // Test keys for register 100 (keys.e2e.spec.ts)
     1001: {
@@ -228,7 +227,7 @@ export async function insertData(sequelize) {
       to_search_string: '(record) => { return [record.data.name]; }',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     1002: {
       id: 1002,
@@ -246,7 +245,7 @@ export async function insertData(sequelize) {
       to_search_string: '(record) => { return [record.data.title]; }',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     // Test keys for register 200 (records.e2e.spec.ts)
     2001: {
@@ -265,14 +264,15 @@ export async function insertData(sequelize) {
       to_search_string: '(record) => { return [record.data.name]; }',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     2002: {
       id: 2002,
       register_id: 200,
       name: 'Records Test Key 2',
       description: 'Second test key for records tests',
-      schema: '{"type":"object","properties":{"field1":{"type":"string","public":true},"field2":{"type":"number","public":true}},"required":["field1"]}',
+      schema:
+        '{"type":"object","properties":{"field1":{"type":"string","public":true},"field2":{"type":"number","public":true}},"required":["field1"]}',
       parent_id: null,
       meta: '{"isTest":true}',
       created_by: 'test-user',
@@ -283,7 +283,7 @@ export async function insertData(sequelize) {
       to_search_string: '(record) => { return [record.data.field1]; }',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     // Test keys for register 800 (encryption.e2e.spec.ts)
     8001: {
@@ -291,7 +291,8 @@ export async function insertData(sequelize) {
       register_id: 800,
       name: 'Витяг про шифрування',
       description: 'Test key for encryption tests',
-      schema: '{"type":"object","properties":{"RET_ID":{"type":"string","public":true},"NAME":{"type":"string","public":true},"RC_AR_TYPE":{"type":"string","public":true},"isFull":{"type":"boolean","public":true}},"required":[]}',
+      schema:
+        '{"type":"object","properties":{"RET_ID":{"type":"string","public":true},"NAME":{"type":"string","public":true},"RC_AR_TYPE":{"type":"string","public":true},"isFull":{"type":"boolean","public":true}},"required":[]}',
       parent_id: null,
       meta: '{"isTest":true}',
       created_by: 'test-user',
@@ -302,7 +303,7 @@ export async function insertData(sequelize) {
       to_search_string: '(record) => { return [record.data.RET_ID]; }',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
+      is_encrypted: false
     },
     8002: {
       id: 8002,
@@ -320,8 +321,8 @@ export async function insertData(sequelize) {
       to_search_string: '(record) => { return [record.data.title]; }',
       to_export: '(record) => { return null; }',
       access_mode: 'full',
-      is_encrypted: false,
-    },
+      is_encrypted: false
+    }
   };
 
   // Keys
@@ -347,10 +348,10 @@ export async function insertData(sequelize) {
           key.to_search_string,
           key.to_export,
           key.access_mode,
-          key.is_encrypted,
-        ],
+          key.is_encrypted
+        ]
       },
-      { raw: true },
+      { raw: true }
     );
   }
 
@@ -370,7 +371,7 @@ export async function insertData(sequelize) {
       search_string_2: '88490',
       search_string_3: '|13|14|15|16|18|27|',
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '87617e50-09b8-11ee-8bd8-f1f3dc4af6ad': {
       id: '87617e50-09b8-11ee-8bd8-f1f3dc4af6ad',
@@ -387,7 +388,7 @@ export async function insertData(sequelize) {
       search_string_2: '88554',
       search_string_3: '|13|14|15|16|18|27|',
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '8b3828d0-09b8-11ee-8bd8-f1f3dc4af6ad': {
       id: '8b3828d0-09b8-11ee-8bd8-f1f3dc4af6ad',
@@ -404,7 +405,7 @@ export async function insertData(sequelize) {
       search_string_2: '88519',
       search_string_3: '|8|13|14|15|16|18|27|',
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '8ade9720-09b8-11ee-8bd8-f1f3dc4af6ad': {
       id: '8ade9720-09b8-11ee-8bd8-f1f3dc4af6ad',
@@ -421,7 +422,7 @@ export async function insertData(sequelize) {
       search_string_2: '89783',
       search_string_3: '|8|13|14|15|16|18|27|',
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '8940ecb0-09b8-11ee-8bd8-f1f3dc4af6ad': {
       id: '8940ecb0-09b8-11ee-8bd8-f1f3dc4af6ad',
@@ -438,7 +439,7 @@ export async function insertData(sequelize) {
       search_string_2: '89028',
       search_string_3: '|13|14|15|16|18|27|',
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '3bdecae2-7d38-11ec-a6de-b57280148b1b': {
       id: '3bdecae2-7d38-11ec-a6de-b57280148b1b',
@@ -455,7 +456,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '3bdecaf1-7d38-11ec-a6de-b57280148b1b': {
       id: '3bdecaf1-7d38-11ec-a6de-b57280148b1b',
@@ -472,7 +473,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '3bdea3f8-7d38-11ec-a6de-b57280148b1b': {
       id: '3bdea3f8-7d38-11ec-a6de-b57280148b1b',
@@ -489,7 +490,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '3bdea3fd-7d38-11ec-a6de-b57280148b1b': {
       id: '3bdea3fd-7d38-11ec-a6de-b57280148b1b',
@@ -506,7 +507,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '3bdea402-7d38-11ec-a6de-b57280148b1b': {
       id: '3bdea402-7d38-11ec-a6de-b57280148b1b',
@@ -523,7 +524,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '99afab63-7d38-11ec-a6de-b57280148b1b': {
       id: '99afab63-7d38-11ec-a6de-b57280148b1b',
@@ -540,7 +541,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '99afab68-7d38-11ec-a6de-b57280148b1b': {
       id: '99afab68-7d38-11ec-a6de-b57280148b1b',
@@ -557,7 +558,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '99afab6a-7d38-11ec-a6de-b57280148b1b': {
       id: '99afab6a-7d38-11ec-a6de-b57280148b1b',
@@ -574,7 +575,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '99afab6f-7d38-11ec-a6de-b57280148b1b': {
       id: '99afab6f-7d38-11ec-a6de-b57280148b1b',
@@ -591,7 +592,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '60d82005-7d38-11ec-a6de-b57280148b1b': {
       id: '60d82005-7d38-11ec-a6de-b57280148b1b',
@@ -608,7 +609,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '44108792-7d37-11ec-a6de-b57280148b1b': {
       id: '44108792-7d37-11ec-a6de-b57280148b1b',
@@ -625,7 +626,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '44108793-7d37-11ec-a6de-b57280148b1b': {
       id: '44108793-7d37-11ec-a6de-b57280148b1b',
@@ -642,7 +643,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '4410aea3-7d37-11ec-a6de-b57280148b1b': {
       id: '4410aea3-7d37-11ec-a6de-b57280148b1b',
@@ -659,7 +660,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '4410aea8-7d37-11ec-a6de-b57280148b1b': {
       id: '4410aea8-7d37-11ec-a6de-b57280148b1b',
@@ -676,7 +677,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '44108794-7d37-11ec-a6de-b57280148b1b': {
       id: '44108794-7d37-11ec-a6de-b57280148b1b',
@@ -693,7 +694,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     // Test records for register 800 / key 8001 (encryption tests)
     '80000001-0000-0000-0000-000000000001': {
@@ -711,7 +712,7 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
+      is_encrypted: false
     },
     '80000001-0000-0000-0000-000000000002': {
       id: '80000001-0000-0000-0000-000000000002',
@@ -728,8 +729,8 @@ export async function insertData(sequelize) {
       search_string_2: null,
       search_string_3: null,
       signature: null,
-      is_encrypted: false,
-    },
+      is_encrypted: false
+    }
   };
 
   // Records
@@ -754,10 +755,10 @@ export async function insertData(sequelize) {
           record.search_string_2,
           record.search_string_3,
           record.signature,
-          record.is_encrypted,
-        ],
+          record.is_encrypted
+        ]
       },
-      { raw: true },
+      { raw: true }
     );
   }
 
@@ -765,19 +766,13 @@ export async function insertData(sequelize) {
   // Get the max ID from fixtures and set sequences to start after that
   const maxRegisterId = Math.max(...Object.keys(REGISTERS).map(Number));
   const maxKeyId = Math.max(...Object.keys(KEYS).map(Number));
-  
-  await sequelize.query(
-    `SELECT setval('registers_id_seq', ${maxRegisterId + 100}, false)`,
-    { raw: true },
-  );
-  await sequelize.query(
-    `SELECT setval('keys_id_seq', ${maxKeyId + 100}, false)`,
-    { raw: true },
-  );
+
+  await sequelize.query(`SELECT setval('registers_id_seq', ${maxRegisterId + 100}, false)`, { raw: true });
+  await sequelize.query(`SELECT setval('keys_id_seq', ${maxKeyId + 100}, false)`, { raw: true });
 
   return {
     REGISTERS,
     KEYS,
-    RECORDS,
+    RECORDS
   };
 }

--- a/components/register/tests/test-harness.ts
+++ b/components/register/tests/test-harness.ts
@@ -43,10 +43,7 @@ export class TestHarness {
   private uniqueDbName?: string;
 
   constructor() {
-    this.config = Multiconf.get(
-      process.env.CONFIG_PATH || '../../config-templates/register',
-      'KITSOFT_REGISTER_'
-    ) as unknown as Config;
+    this.config = Multiconf.get(process.env.CONFIG_PATH || '../../config-templates/register', 'KITSOFT_REGISTER_') as unknown as Config;
   }
 
   getConfig(): Config {


### PR DESCRIPTION
- register: lint's tests glob previously pointed at a nonexistent test/ directory, so tests/**/*.ts was never actually linted; fix the resulting prettier violations now that it correctly targets tests/
- admin-api: fix an unrelated pre-existing prettier violation in cabinet_menu.ts that was also failing the Lint workflow