### PR TITLE
feat(back-core): add shared Sandbox module for low-code eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "liquio",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "liquio",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/packages/back-core/package-lock.json
+++ b/packages/back-core/package-lock.json
@@ -1,15 +1,25 @@
 {
-  "name": "back-core",
+  "name": "@liquio/back-core",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "back-core",
+      "name": "@liquio/back-core",
       "version": "0.1.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
+      "dependencies": {
+        "acorn": "^8.18.0",
+        "iconv-lite": "^0.7.3",
+        "isolated-vm": "^7.0.1",
+        "lodash": "^4.18.1",
+        "lru-cache": "^11.5.2",
+        "moment": "^2.30.1",
+        "sequelize": "^6.37.8"
+      },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/lodash": "^4.17.25",
         "@types/node": "^26.1.2",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
@@ -108,6 +118,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -1347,6 +1367,15 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1406,11 +1435,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1421,6 +1462,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -2041,7 +2088,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2591,7 +2637,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2646,6 +2691,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dottie": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.7.tgz",
+      "integrity": "sha512-7lAK2A0b3zZr3UC5aE69CPdCFR4RHW1o2Dr74TqFykxkUCBXSRJum/yPc7g8zRHJqWKomPLHwFLLoUnn8PXXRg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3285,6 +3337,22 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3324,6 +3392,15 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
+      "engines": [
+        "node >= 0.4.0"
+      ],
+      "license": "MIT"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -3413,6 +3490,19 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isolated-vm": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-7.0.1.tgz",
+      "integrity": "sha512-nBCQ1hXEaYKYJ79wwfhaF44ITOJC30Hw0wPEsFeNsdD3hdeKK7FW1SGMQYBUA+qasvkqdOazI+iBuq0lcbN/aw==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4239,6 +4329,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4247,13 +4343,12 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/make-dir": {
@@ -4355,11 +4450,31 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -4391,6 +4506,17 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4597,6 +4723,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4842,6 +4974,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/retry-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.1.1.tgz",
+      "integrity": "sha512-hMD7odLOt3LkTjcif8aRZqi/hybjpLNgSk5oF5FCowfCjok6LukpN2bDX7R5wDmbgBQFn7YoBxSagmtXHaJYJw==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4850,6 +4994,89 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/sequelize": {
+      "version": "6.37.8",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.8.tgz",
+      "integrity": "sha512-HJ0IQFqcTsTiqbEgiuioYFMSD00TP6Cz7zoTti+zVVBwVe9fEhev9cH6WnM3XU31+ABS356durAb99ZuOthnKw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/sequelize"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.8",
+        "@types/validator": "^13.7.17",
+        "debug": "^4.3.4",
+        "dottie": "^2.0.6",
+        "inflection": "^1.13.4",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.43",
+        "pg-connection-string": "^2.6.1",
+        "retry-as-promised": "^7.0.4",
+        "semver": "^7.5.4",
+        "sequelize-pool": "^7.1.0",
+        "toposort-class": "^1.0.1",
+        "uuid": "^8.3.2",
+        "validator": "^13.9.0",
+        "wkx": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ibm_db": {
+          "optional": true
+        },
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "snowflake-sdk": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sequelize-pool": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/sequelize/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -5226,6 +5453,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5418,7 +5651,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -5500,6 +5732,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -5513,6 +5755,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/walker": {
@@ -5539,6 +5790,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wkx": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/word-wrap": {

--- a/packages/back-core/package.json
+++ b/packages/back-core/package.json
@@ -22,8 +22,18 @@
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "test": "jest"
   },
+  "dependencies": {
+    "acorn": "^8.18.0",
+    "iconv-lite": "^0.7.3",
+    "isolated-vm": "^7.0.1",
+    "lodash": "^4.18.1",
+    "lru-cache": "^11.5.2",
+    "moment": "^2.30.1",
+    "sequelize": "^6.37.8"
+  },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/lodash": "^4.17.25",
     "@types/node": "^26.1.2",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",

--- a/packages/back-core/src/common/sandbox.spec.ts
+++ b/packages/back-core/src/common/sandbox.spec.ts
@@ -511,4 +511,161 @@ describe('Sandbox', () => {
       expect(contextB.eval('typeof a')).toBe('undefined');
     });
   });
+
+  describe('isolationLevel: isolated-vm', () => {
+    const vmConfig = { ...config, isolationLevel: 'isolated-vm' as const };
+
+    it('should execute a simple code', () => {
+      const sandbox = new Sandbox(vmConfig);
+      expect(sandbox.eval('1 + 1')).toBe(2);
+    });
+
+    it('should execute a code with arguments via evalWithArgs', () => {
+      const sandbox = new Sandbox(vmConfig);
+      const result = sandbox.evalWithArgs('(a, b) => a + b', [1, 2]);
+      expect(result).toBe(3);
+    });
+
+    it('should operate on plain object/array arguments via evalWithArgs', () => {
+      const sandbox = new Sandbox(vmConfig);
+      const result = sandbox.evalWithArgs('(items) => items.filter((i) => i.active).map((i) => i.name)', [
+        [
+          { name: 'a', active: true },
+          { name: 'b', active: false },
+          { name: 'c', active: true },
+        ],
+      ]);
+      expect(result).toEqual(['a', 'c']);
+    });
+
+    it('should eval the same real business process example as function isolation', () => {
+      const sandbox = new Sandbox(vmConfig);
+      const result = sandbox.evalWithArgs(
+        `(documents) => {
+          const unit = documents
+            ?.find((item => item?.documentTemplateId === 988071001))
+            ?.data
+            ?.calculated
+            ?.moderatorUnitIds;
+          return unit || []
+        };`,
+        [
+          [
+            {
+              documentTemplateId: 988071001,
+              data: {
+                calculated: {
+                  moderatorUnitIds: [1, 2, 3],
+                },
+              },
+            },
+          ],
+        ],
+      );
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('should bridge sync default global helpers', () => {
+      const sandbox = new Sandbox(vmConfig);
+      expect(sandbox.evalWithArgs('() => getMd5Hash("test")', [])).toBe('098f6bcd4621d373cade4e832627b4f6');
+      expect(sandbox.evalWithArgs('() => base64Encode("hello")', [])).toBe('aGVsbG8=');
+      expect(sandbox.evalWithArgs('() => toBase64("hello")', [])).toBe('aGVsbG8=');
+      expect(sandbox.evalWithArgs('() => typeof randomUUID()', [])).toBe('string');
+    });
+
+    it('should await bridged async globals passed via evalWithArgs options', async () => {
+      const sandbox = new Sandbox(vmConfig);
+      const result = sandbox.evalWithArgs('(a) => test(a)', [42], {
+        isAsync: true,
+        global: { test: async (a: number) => a + 1 },
+      });
+      // isolated-vm's native Promise is a different realm from Jest's, so assert duck-typed
+      // thenable-ness here rather than `toBeInstanceOf(Promise)`.
+      expect(typeof result.then).toBe('function');
+      await expect(result).resolves.toBe(43);
+    });
+
+    it('should automatically add "async" to functions if isAsync is true', async () => {
+      const sandbox = new Sandbox(vmConfig);
+      const result = sandbox.evalWithArgs('(a) => await test(a)', [42], { isAsync: true, global: { test: async (a: number) => a + 1 } });
+      expect(typeof result.then).toBe('function');
+      await expect(result).resolves.toBe(43);
+    });
+
+    it('should use workflow template global functions, sync and async', async () => {
+      const sandbox = new Sandbox(vmConfig);
+
+      const models = {
+        models: {
+          workflowTemplate: {
+            model: {
+              findAll: jest.fn().mockResolvedValue([
+                { id: 1, data: { globalFunctions: { greet: '(name) => `hi ${name}`' } } },
+                { id: 2, data: { globalFunctions: { greetAsync: 'async (name) => `hi ${name}`' } } },
+              ]),
+            },
+          },
+        },
+      };
+      await sandbox.init(models);
+
+      expect(sandbox.evalWithArgs('() => $.workflow.greet("bob")', [], { workflowTemplateId: 1 })).toBe('hi bob');
+
+      // The automatic bare-identifier `await` transform only recognizes top-level global names,
+      // not nested paths like `$.workflow.greetAsync`, so the caller awaits it explicitly here —
+      // same requirement as function isolation, just more strictly enforced: crossing the
+      // isolate boundary can't structured-clone an un-awaited Promise.
+      const asyncResult = sandbox.evalWithArgs('async (name) => await $.workflow.greetAsync(name)', ['bob'], {
+        workflowTemplateId: 2,
+        isAsync: true,
+      });
+      await expect(asyncResult).resolves.toBe('hi bob');
+    });
+
+    it('should not leak assignments to predefined host globals, unlike function isolation', () => {
+      const original = (fetch as any).toString();
+      const sandbox = new Sandbox(vmConfig);
+
+      sandbox.eval('fetch = function() { return "hijacked"; }')();
+
+      expect((fetch as any).toString()).toBe(original);
+    });
+
+    it('should not expose the host global object', () => {
+      const sandbox = new Sandbox(vmConfig);
+      expect(sandbox.eval('typeof process')).toBe('undefined');
+      expect(sandbox.eval('typeof require')).toBe('undefined');
+    });
+
+    it('should not expose rich library namespaces (_, iconv, moment, crypto)', () => {
+      const sandbox = new Sandbox(vmConfig);
+      expect(sandbox.eval('typeof _')).toBe('undefined');
+      expect(sandbox.eval('typeof iconv')).toBe('undefined');
+      expect(sandbox.eval('typeof moment')).toBe('undefined');
+      expect(sandbox.eval('typeof crypto')).toBe('undefined');
+    });
+
+    it('should support a custom global added via addGlobal', () => {
+      const sandbox = new Sandbox(vmConfig);
+      sandbox.addGlobal('double', (n: number) => n * 2);
+      expect(sandbox.evalWithArgs('(n) => double(n)', [21])).toBe(42);
+    });
+
+    it('should wrap syntax errors the same way as function isolation', () => {
+      const sandbox = new Sandbox(vmConfig);
+      expect(() => sandbox.evalWithArgs("(documents, events) => { return 'Тестовий юніт; }", [])).toThrow(/^Sandbox error: /);
+    });
+
+    it('should wrap runtime errors the same way as function isolation', () => {
+      const sandbox = new Sandbox(vmConfig);
+      expect(() => sandbox.evalWithArgs('() => { throw new Error("boom"); }', [])).toThrow('Sandbox error: "boom"');
+    });
+
+    it('should reuse the compiled function for identical code and options', () => {
+      const sandbox = new Sandbox(vmConfig);
+      const first = sandbox.eval('() => 1');
+      const second = sandbox.eval('() => 1');
+      expect(second).toBe(first);
+    });
+  });
 });

--- a/packages/back-core/src/common/sandbox.spec.ts
+++ b/packages/back-core/src/common/sandbox.spec.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from './sandbox';
+import { Sandbox, SandboxIsolationLevel } from './sandbox';
 import { appendTraceMeta, runInAsyncLocalStorage } from './async_local_storage';
 
 const log = { save: jest.fn() };
@@ -513,7 +513,7 @@ describe('Sandbox', () => {
   });
 
   describe('isolationLevel: isolated-vm', () => {
-    const vmConfig = { ...config, isolationLevel: 'isolated-vm' as const };
+    const vmConfig = { ...config, isolationLevel: SandboxIsolationLevel.IsolatedVm };
 
     it('should execute a simple code', () => {
       const sandbox = new Sandbox(vmConfig);

--- a/packages/back-core/src/common/sandbox.spec.ts
+++ b/packages/back-core/src/common/sandbox.spec.ts
@@ -1,0 +1,514 @@
+import { Sandbox } from './sandbox';
+import { appendTraceMeta, runInAsyncLocalStorage } from './async_local_storage';
+
+const log = { save: jest.fn() };
+
+describe('Sandbox', () => {
+  const config = { getLog: () => log };
+
+  beforeEach(() => {
+    log.save.mockClear();
+  });
+
+  it('should execute a simple code', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.eval('1 + 1');
+    expect(result).toBe(2);
+  });
+
+  it('should execute a code with arguments', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.evalWithArgs('(a, b) => a + b', [1, 2]);
+    expect(result).toBe(3);
+  });
+
+  it('should return the default value if code is empty', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.eval('', { defaultValue: 42 });
+    expect(result).toBe(42);
+  });
+
+  it('should cleanup comments and trim code', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.eval('\n/* comment */\n 1 + 1 // comment');
+    expect(result).toBe(2);
+  });
+
+  it('should check for arrow functions and return raw string if not', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.evalWithArgs('1 + 1', [], { checkArrow: true });
+    expect(result).toBe('1 + 1');
+  });
+
+  it('should check for arrow functions and return evaluated code if found', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.eval(' (a, b) => a + b', { checkArrow: true });
+    expect(result).toBeInstanceOf(Function);
+    expect((result as any)(1, 2)).toBe(3);
+  });
+
+  it('should transform functions to async', async () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.evalWithArgs('(a) => test(a)', [42], {
+      isAsync: true,
+      global: { test: async (a: number) => a + 1 },
+    });
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBe(43);
+  });
+
+  it('should prevent access to global reference', () => {
+    (global as any).test = 'test';
+    const sandbox = new Sandbox(config);
+    const result = sandbox.eval('Object.keys(global)');
+    expect(result).toEqual([]);
+    sandbox.eval('global.test = "test2"');
+    expect((global as any).test).toBe('test');
+
+    // Warning: Predefined globals are not protected.
+    sandbox.eval('fetch = function() { return "fetch" }');
+    expect((fetch as any)()).toBe('fetch');
+  });
+
+  it('should use default globals', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.eval('getMd5Hash("test")');
+    expect(result).toBe('098f6bcd4621d373cade4e832627b4f6');
+  });
+
+  it('should expose sha256, uuid and crypto helpers as default globals', () => {
+    const sandbox = new Sandbox(config);
+    expect(sandbox.eval('getSha256Hash("test")')).toBe('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08');
+    expect(sandbox.eval('typeof uuid()')).toBe('string');
+    expect(sandbox.eval('typeof uuidv4()')).toBe('string');
+    expect(sandbox.eval('typeof crypto.randomUUID')).toBe('function');
+  });
+
+  it('should compute a sha512 hash, with and without an hmac secret', () => {
+    const sandbox = new Sandbox(config);
+    expect(sandbox.eval('getSha512Hash("test")')).toBe(
+      'ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff',
+    );
+    expect(sandbox.eval('getSha512Hash("test", { hmac: "secret" })')).toBe(
+      'f8a4f0a209167bc192a1bffaa01ecdb09e06c57f96530d92ec9ccea0090d290e55071306d6b654f26ae0c8721f7e48a2d7130b881151f2cec8d61d941a6be88a',
+    );
+  });
+
+  it('should encode/decode base64 helpers', () => {
+    const sandbox = new Sandbox(config);
+    expect(sandbox.eval('base64Encode("hello")')).toBe('aGVsbG8=');
+    expect(sandbox.eval('base64Decode("aGVsbG8=")')).toBe('hello');
+    expect(sandbox.eval('toBase64("hello")')).toBe('aGVsbG8=');
+    expect(sandbox.eval('base64Decode(toBase64("round-trip"))')).toBe('round-trip');
+  });
+
+  it('should override globals if needed', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.eval('Object.keys(global)', {
+      global: { global: { a: 1 } },
+    });
+    expect(result).toEqual(['a']);
+  });
+
+  it('should add a custom global via addGlobal', () => {
+    const sandbox = new Sandbox(config);
+    sandbox.addGlobal('double', (n: number) => n * 2);
+    expect(sandbox.eval('double(21)')).toBe(42);
+  });
+
+  it('should throw when adding a global that already exists', () => {
+    const sandbox = new Sandbox(config);
+    expect(() => sandbox.addGlobal('_', {})).toThrow('Global "_" already exists');
+  });
+
+  it('should throw when adding a global with an invalid name', () => {
+    const sandbox = new Sandbox(config);
+    expect(() => sandbox.addGlobal('', 1)).toThrow('Global name must be a non-empty string');
+    expect(() => sandbox.addGlobal(undefined as any, 1)).toThrow('Global name must be a non-empty string');
+  });
+
+  it('should throw when adding a global with an undefined value', () => {
+    const sandbox = new Sandbox(config);
+    expect(() => sandbox.addGlobal('newGlobal', undefined)).toThrow('Global value cannot be undefined');
+  });
+
+  it('should return the sandbox instance so addGlobal calls can be chained', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.addGlobal('one', 1).addGlobal('two', 2);
+    expect(result).toBe(sandbox);
+    expect(sandbox.eval('one + two')).toBe(3);
+  });
+
+  it('should eval some real business process examples', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.evalWithArgs(
+      `(documents) => {
+        const unit = documents
+          ?.find((item => item?.documentTemplateId === 988071001))
+          ?.data
+          ?.calculated
+          ?.moderatorUnitIds;
+        return unit || []
+      };`,
+      [
+        [
+          {
+            documentTemplateId: 988071001,
+            data: {
+              calculated: {
+                moderatorUnitIds: [1, 2, 3],
+              },
+            },
+          },
+        ],
+      ],
+    );
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('should throw an error if code is not a string', () => {
+    const sandbox = new Sandbox(config);
+
+    expect(() => sandbox.evalWithArgs(undefined, undefined, { throwOnUndefined: true })).toThrow('Sandbox error: "Code is undefined"');
+
+    expect(() =>
+      sandbox.evalWithArgs(undefined, undefined, {
+        throwOnUndefined: true,
+        meta: { fn: 'testFn' },
+      }),
+    ).toThrow('Sandbox error: "Code is undefined" in testFn');
+
+    expect(() =>
+      sandbox.evalWithArgs(undefined, undefined, {
+        throwOnUndefined: true,
+        meta: { fn: 'testFn', caller: 'testCaller' },
+      }),
+    ).toThrow('Sandbox error: "Code is undefined" in testFn called by testCaller');
+  });
+
+  it('should not work with a plain string without checkArrow', () => {
+    const sandbox = new Sandbox(config);
+
+    expect(() => sandbox.evalWithArgs('Витяг з Єдиного державного реєстру ветеранів війни', [])).toThrow('Sandbox error: "Unexpected token (1:6)"');
+  });
+
+  it('should work with a plain string with checkArrow', () => {
+    const sandbox = new Sandbox(config);
+
+    const result = sandbox.evalWithArgs('Витяг з Єдиного державного реєстру ветеранів війни', [], { checkArrow: true });
+
+    expect(result).toBe('Витяг з Єдиного державного реєстру ветеранів війни');
+  });
+
+  it('should work with a quoted string', () => {
+    const sandbox = new Sandbox(config);
+
+    const result = sandbox.evalWithArgs('"Витяг з Єдиного державного реєстру ветеранів війни"', []);
+
+    expect(result).toBe('Витяг з Єдиного державного реєстру ветеранів війни');
+  });
+
+  it('should handle syntax errors', () => {
+    const sandbox = new Sandbox(config);
+
+    expect(() => sandbox.evalWithArgs("(documents, events) => { return 'Тестовий юніт; }", [])).toThrow(
+      'Sandbox error: "Unterminated string constant (1:32)"\n  (documents, events) => { return \'Тестовий юніт; }',
+    );
+  });
+
+  it('should automatically add "async" to functions if isAsync is true', () => {
+    const sandbox = new Sandbox(config);
+
+    const result = sandbox.evalWithArgs('(a) => await test(a)', [42], { isAsync: true, global: { test: async (a: number) => a + 1 } });
+    expect(result).toBeInstanceOf(Promise);
+
+    return expect(result).resolves.toBe(43);
+  });
+
+  it('should correctly strip comments and trim code', () => {
+    const sandbox = new Sandbox(config);
+    const result = sandbox.evalWithArgs('\n/* comment */\n() => 1 + 1 // comment', [], { checkArrow: true });
+    expect(result).toBe(2);
+  });
+
+  it('should handle faulty comments with eval', () => {
+    const sandbox = new Sandbox(config);
+
+    const fn = `() => false;
+    // This is a faulty comment
+    return true;`;
+
+    const id = sandbox.eval(fn)();
+    expect(id).toBe(false);
+  });
+
+  it('should handle faulty comments with evalWithArgs', () => {
+    const sandbox = new Sandbox(config);
+
+    const fn = `() => false;
+    // This is a faulty comment
+    return true;`;
+
+    expect(() => sandbox.evalWithArgs(fn, [])).toThrow();
+  });
+
+  it('should evaluate an arrow function with an inline comment (workflow_template workaround)', () => {
+    const sandbox = new Sandbox(config);
+
+    let fn = `(user, unitIds, units) => user.id
+      // inline comment';
+      return false; }
+    `;
+
+    expect(() => sandbox.eval(fn)({ id: 123 }, [1], {})).toThrow();
+
+    const idx = fn.indexOf('//');
+    fn = fn.substring(0, idx).trim();
+    const id = sandbox.eval(fn)({ id: 123 }, [1], {});
+    expect(id).toBe(123);
+  });
+
+  describe('getInstance', () => {
+    it('should throw if the sandbox was never constructed', () => {
+      (Sandbox as any).singleton = undefined;
+      expect(() => Sandbox.getInstance()).toThrow('Sandbox is not initialized.');
+    });
+
+    it('should return the last constructed sandbox', () => {
+      const sandbox = new Sandbox(config);
+      expect(Sandbox.getInstance()).toBe(sandbox);
+    });
+  });
+
+  describe('globalFunctions', () => {
+    let sandbox: Sandbox;
+
+    it('should query for workflow templates', async () => {
+      sandbox = new Sandbox(config);
+
+      const models = {
+        models: {
+          workflowTemplate: {
+            model: {
+              findAll: jest.fn().mockResolvedValue([
+                { id: 1, data: { globalFunctions: 'invalid' } },
+                { id: 2, data: { globalFunctions: {} } },
+                { id: 3, data: { globalFunctions: { testFunc: '(value) => `test-${value}`' } } },
+              ]),
+            },
+          },
+        },
+      };
+
+      await sandbox.init(models);
+
+      expect(sandbox).toBeDefined();
+      expect(log.save).toHaveBeenCalledWith(
+        'sandbox-warning',
+        expect.objectContaining({ workflowTemplateId: 1, message: expect.stringContaining('must be an object') }),
+        'warn',
+      );
+      expect(log.save).toHaveBeenCalledWith('sandbox-global-function', { workflowTemplateId: 3, functionName: 'testFunc' }, 'info');
+    });
+
+    it('should use global functions from workflow templates', () => {
+      const result = sandbox.evalWithArgs('() => $.workflow.testFunc("value")', [], { workflowTemplateId: 3 });
+      expect(result).toBe('test-value');
+    });
+
+    it('should resolve the workflow template ID from trace meta when not passed in options', () => {
+      let result: any;
+      runInAsyncLocalStorage(() => {
+        appendTraceMeta({ workflowTemplateId: 3 });
+        result = sandbox.eval('() => $.workflow.testFunc("value")')();
+      });
+      expect(result).toBe('test-value');
+    });
+
+    it('should log and store a global function that fails to compile', () => {
+      sandbox.updateWorkflowTemplateFunctions(4, { brokenFunc: '(value =>' });
+      expect(log.save).toHaveBeenCalledWith(
+        'sandbox-global-function-error',
+        expect.objectContaining({ workflowTemplateId: 4, functionName: 'brokenFunc' }),
+        'warn',
+      );
+      expect(() => sandbox.evalWithArgs('() => $.workflow.brokenFunc("value")', [], { workflowTemplateId: 4 })).toThrow(
+        'Sandbox error: "$.workflow.brokenFunc is not a function"',
+      );
+    });
+
+    it('should ignore non-string and empty-string global function values', () => {
+      sandbox.updateWorkflowTemplateFunctions(5, { a: 1, b: '', c: '(value) => value' });
+      expect(sandbox.workflowTemplateFunctions[5]).toEqual({ c: expect.any(Function) });
+    });
+
+    it('should throw an error if global functions are not defined for the workflow template', () => {
+      expect(() => sandbox.evalWithArgs('() => $.workflow.testFunc("value")', [], { workflowTemplateId: 1 })).toThrow(
+        'Sandbox error: "$.workflow.testFunc is not a function"',
+      );
+    });
+
+    it('should throw an error if a particular function is not defined in global functions', () => {
+      expect(() => sandbox.evalWithArgs('() => $.workflow.nonExistentFunc("value")', [], { workflowTemplateId: 3 })).toThrow(
+        'Sandbox error: "$.workflow.nonExistentFunc is not a function"',
+      );
+    });
+
+    it('should throw if models are not provided', async () => {
+      const sandbox = new Sandbox(config);
+      await expect(sandbox.init({})).rejects.toThrow('Models are required to initialize the sandbox.');
+    });
+  });
+
+  describe('minifyCode', () => {
+    it('should strip single-line and multi-line comments and trim whitespace', () => {
+      const code = `
+        // leading comment
+        /* block
+           comment */
+        const a = 1;
+      `;
+      expect(Sandbox.minifyCode(code)).toBe('const a = 1;');
+    });
+
+    it('should leave code without comments unchanged apart from trimming', () => {
+      expect(Sandbox.minifyCode('  1 + 1  ')).toBe('1 + 1');
+    });
+  });
+
+  describe('caching', () => {
+    it('should reuse the compiled function for identical code and options', () => {
+      const sandbox = new Sandbox(config);
+      const first = sandbox.eval('() => Math.random()');
+      const second = sandbox.eval('() => Math.random()');
+      expect(second).toBe(first);
+    });
+
+    it('should compile separately when options differ', () => {
+      const sandbox = new Sandbox(config);
+      const first = sandbox.eval('() => 1', { checkArrow: true });
+      const second = sandbox.eval('() => 1', { checkArrow: false });
+      expect(second).not.toBe(first);
+    });
+
+    it('should respect a configured lru_max', () => {
+      const sandbox = new Sandbox({ ...config, lru_max: 1 });
+      sandbox.eval('1 + 1');
+      sandbox.eval('2 + 2');
+      expect(sandbox.cache.size).toBe(1);
+    });
+  });
+
+  describe('eval / evalWithArgs edge cases', () => {
+    it('should return the default value for non-string code', () => {
+      const sandbox = new Sandbox(config);
+      expect(sandbox.eval(null as any, { defaultValue: 'fallback' })).toBe('fallback');
+      expect(sandbox.eval(42 as any, { defaultValue: 'fallback' })).toBe('fallback');
+    });
+
+    it('should return undefined from evalWithArgs when code is undefined and no fallback options are set', () => {
+      const sandbox = new Sandbox(config);
+      expect(sandbox.evalWithArgs(undefined, [])).toBeUndefined();
+    });
+
+    it('should return the defaultValue from evalWithArgs when code is undefined', () => {
+      const sandbox = new Sandbox(config);
+      expect(sandbox.evalWithArgs(undefined, [], { defaultValue: 'fallback' })).toBe('fallback');
+    });
+
+    it('should warn and return the raw value when the evaluated code is not a function', () => {
+      const sandbox = new Sandbox(config);
+      const result = sandbox.evalWithArgs('({ a: 1 })', []);
+      expect(result).toEqual({ a: 1 });
+      expect(log.save).toHaveBeenCalledWith('sandbox-warning', expect.objectContaining({ error: 'Function not found' }), 'warn');
+    });
+
+    it('should return the raw code and skip evaluation when checkArrow is set and the code is not an arrow function', () => {
+      const sandbox = new Sandbox(config);
+      const result = sandbox.evalWithArgs('({ a: 1 })', [], { checkArrow: true });
+      expect(result).toBe('({ a: 1 })');
+      expect(log.save).not.toHaveBeenCalledWith('sandbox-warning', expect.anything(), 'warn');
+    });
+
+    it('should slice extra arguments down to the arrow function arity', () => {
+      const sandbox = new Sandbox(config);
+      const result = sandbox.evalWithArgs('(a, b) => [a, b]', [1, 2, 3, 4]);
+      expect(result).toEqual([1, 2]);
+    });
+
+    it('should log duration and call details when config.logging is enabled', () => {
+      const sandbox = new Sandbox({ ...config, logging: true });
+      const result = sandbox.evalWithArgs('(a, b) => a + b', [1, 2]);
+      expect(result).toBe(3);
+      expect(log.save).toHaveBeenCalledWith('sandbox-eval', expect.objectContaining({ isArrowFunction: true, arrowParams: ['a', 'b'] }));
+    });
+
+    it('should not log per-call details when config.logging is not enabled', () => {
+      const sandbox = new Sandbox(config);
+      sandbox.evalWithArgs('(a, b) => a + b', [1, 2]);
+      expect(log.save).not.toHaveBeenCalledWith('sandbox-eval', expect.anything());
+    });
+  });
+
+  describe('config options', () => {
+    it('should use a custom globalFunctionsObject name', () => {
+      const sandbox = new Sandbox({ ...config, globalFunctionsObject: 'helpers' });
+      expect(sandbox.eval('typeof helpers.workflow')).toBe('object');
+      expect(sandbox.eval('typeof $')).toBe('undefined');
+    });
+
+    it('should fall back to global.log when no getLog is configured', () => {
+      const globalLog = { save: jest.fn() };
+      (global as any).log = globalLog;
+      try {
+        const sandbox = new Sandbox({});
+        sandbox.throwError(new Error('boom'), 'code', {});
+        expect(globalLog.save).toHaveBeenCalledWith('sandbox-error', expect.objectContaining({ error: 'boom' }), 'error');
+      } finally {
+        delete (global as any).log;
+      }
+    });
+  });
+
+  describe('createContext / SandboxContext', () => {
+    it('should evaluate code directly inside the isolate', () => {
+      const sandbox = new Sandbox(config);
+      const context = sandbox.createContext();
+      expect(context.eval('1 + 1')).toBe(2);
+    });
+
+    it('should expose a value set via set() as a readable Reference inside the isolate', () => {
+      const sandbox = new Sandbox(config);
+      const context = sandbox.createContext();
+      context.set('obj', { a: 42 });
+      expect(context.eval('obj.getSync("a")')).toBe(42);
+    });
+
+    it('should expose a function set via set() as a callable Reference inside the isolate', () => {
+      const sandbox = new Sandbox(config);
+      const context = sandbox.createContext();
+      context.set('double', (n: number) => n * 2);
+      expect(context.eval('double.applySync(undefined, [21])')).toBe(42);
+    });
+
+    it('should allow chaining set() calls', () => {
+      const sandbox = new Sandbox(config);
+      const context = sandbox.createContext();
+      const chained = context.set('a', 1).set('b', 2);
+      expect(chained).toBe(context);
+      expect(context.eval('typeof a')).toBe('object');
+      expect(context.eval('typeof b')).toBe('object');
+    });
+
+    it('should isolate separate contexts from the same sandbox from each other', () => {
+      const sandbox = new Sandbox(config);
+      const contextA = sandbox.createContext();
+      const contextB = sandbox.createContext();
+
+      contextA.set('a', 1);
+
+      expect(contextA.eval('typeof a')).toBe('object');
+      expect(contextB.eval('typeof a')).toBe('undefined');
+    });
+  });
+});

--- a/packages/back-core/src/common/sandbox.ts
+++ b/packages/back-core/src/common/sandbox.ts
@@ -1,0 +1,514 @@
+import vm from 'isolated-vm';
+import iconv from 'iconv-lite';
+import moment from 'moment';
+import _ from 'lodash';
+import * as crypto from 'node:crypto';
+import acorn from 'acorn';
+import { literal } from 'sequelize';
+import { LRUCache } from 'lru-cache';
+
+import { getTraceMeta } from './async_local_storage';
+
+const { randomUUID } = crypto;
+
+const DEFAULT_GLOBAL_FUNCTIONS_OBJECT = '$';
+const DEFAULT_LRU_MAX = 1000; // 1000 items
+
+/**
+ * Minimal structural shape for the log object each component exposes on `global.log`.
+ * Consumers may instead pass a `getLog` function in the sandbox config to avoid
+ * depending on a process-wide global.
+ */
+export interface SandboxLog {
+  save(event: string, data: Record<string, any>, level?: string): void;
+}
+
+export interface SandboxConfig {
+  /** Name of the object that exposes workflow template global functions inside evaluated code. Default: '$'. */
+  globalFunctionsObject?: string;
+  /** Max number of compiled functions to keep in the eval cache. Default: 1000. */
+  lru_max?: number;
+  /** Log every eval/evalWithArgs call (in addition to warnings/errors, which are always logged). */
+  logging?: boolean;
+  /** Returns the logger to use. Defaults to reading `global.log`. */
+  getLog?: () => SandboxLog;
+  [key: string]: any;
+}
+
+export interface EvalOptions {
+  /** Extra globals to expose to the evaluated code, merged over the sandbox defaults. */
+  global?: Record<string, any>;
+  /** Evaluate code as an async function, awaiting any async globals it calls. */
+  isAsync?: boolean;
+  /** Throw an error if code is undefined. */
+  throwOnUndefined?: boolean;
+  /** Check for arrow functions; return the raw code string if it isn't one. */
+  checkArrow?: boolean;
+  /** Workflow template ID whose global functions should be exposed as `$.workflow`. */
+  workflowTemplateId?: string | number;
+  /** Default value to return if code is empty/undefined. */
+  defaultValue?: any;
+  /** Meta data for logging. */
+  meta?: Record<string, any>;
+  [key: string]: any;
+}
+
+/**
+ * Sandbox for evaluating user-provided (low-code) JavaScript snippets outside of a full
+ * isolated-vm context, plus a factory for true `isolated-vm` contexts via `createContext()`.
+ *
+ * Consolidates the near-identical `Sandbox` implementations previously duplicated across
+ * the task, admin-api, event, gateway, and persist-link components.
+ */
+export class Sandbox {
+  private static singleton: Sandbox;
+
+  config: SandboxConfig;
+  isolate: vm.Isolate;
+  globalFunctionsObject: string;
+  defaultGlobals: Record<string, any>;
+  cache: LRUCache<string, any>;
+  workflowTemplateFunctions: Record<string | number, Record<string, any>>;
+
+  /**
+   * Get the singleton instance of the Sandbox.
+   * @returns {Sandbox}
+   */
+  static getInstance(): Sandbox {
+    if (!Sandbox.singleton) {
+      throw new Error('Sandbox is not initialized.');
+    }
+    return Sandbox.singleton;
+  }
+
+  /**
+   * @param {SandboxConfig} config Sandbox configuration.
+   */
+  constructor(config?: SandboxConfig) {
+    this.config = config || {};
+
+    // Create an isolation container
+    this.isolate = new vm.Isolate({ memoryLimit: 128 });
+
+    // Set the global functions object, default is '$'
+    this.globalFunctionsObject = this.config.globalFunctionsObject || DEFAULT_GLOBAL_FUNCTIONS_OBJECT;
+
+    // Create a new context and import the default globals
+    this.defaultGlobals = {
+      _,
+      iconv,
+      moment,
+      crypto,
+      randomUUID,
+      uuid: randomUUID,
+      uuidv4: randomUUID,
+      getMd5Hash,
+      getSha256Hash,
+      getSha512Hash,
+      base64Decode,
+      base64Encode,
+      toBase64,
+      global: {},
+    };
+
+    // Create a cache for evaluated functions
+    this.cache = new LRUCache({ max: this.config.lru_max ?? DEFAULT_LRU_MAX });
+
+    // A store for workflow template global functions
+    this.workflowTemplateFunctions = {};
+
+    Sandbox.singleton = this;
+  }
+
+  /**
+   * Register a new default global for evaluated code. Fails if the name is already taken,
+   * so components don't silently shadow one of the built-in helpers or each other's globals.
+   * @param {string} name Global name.
+   * @param {any} value Global value.
+   * @returns {Sandbox}
+   */
+  addGlobal(name: string, value: any): Sandbox {
+    if (typeof name !== 'string' || name.length === 0) {
+      throw new Error('Global name must be a non-empty string');
+    }
+    if (value === undefined) {
+      throw new Error('Global value cannot be undefined');
+    }
+    if (this.defaultGlobals[name] !== undefined) {
+      throw new Error(`Global "${name}" already exists`);
+    }
+    this.defaultGlobals[name] = value;
+    return this;
+  }
+
+  /**
+   * Load workflow template global functions from the database into the sandbox.
+   * @param {object} models Sequelize models container exposing `models.workflowTemplate`.
+   * @returns {Promise<void>}
+   */
+  async init(models: any): Promise<void> {
+    if (!models?.models?.workflowTemplate) {
+      throw new Error('Models are required to initialize the sandbox.');
+    }
+
+    // Select all workflow templates that have global functions defined in their data.
+    const workflowTemplates = await models.models.workflowTemplate.model.findAll({
+      where: literal("data::jsonb ? 'globalFunctions'"),
+      attributes: ['id', 'data'],
+    });
+
+    // Iterate through each workflow template and extract global functions.
+    for (const workflowTemplate of workflowTemplates) {
+      const globalFunctions = workflowTemplate.data?.globalFunctions || {};
+
+      if (typeof globalFunctions !== 'object') {
+        this.getLog().save(
+          'sandbox-warning',
+          {
+            workflowTemplateId: workflowTemplate.id,
+            message: 'Invalid globalFunctions for workflow template, must be an object.',
+            data: workflowTemplate.data,
+          },
+          'warn',
+        );
+        continue;
+      }
+
+      this.updateWorkflowTemplateFunctions(workflowTemplate.id, globalFunctions);
+    }
+  }
+
+  /**
+   * Compile and store the global functions of a single workflow template.
+   * @param {string|number} workflowTemplateId Workflow template ID.
+   * @param {object} globalFunctions Map of function name to function source code.
+   */
+  updateWorkflowTemplateFunctions(workflowTemplateId: string | number, globalFunctions: Record<string, any>): void {
+    // Filter out empty strings.
+    const pairs = Object.entries(globalFunctions || {}).filter(([, v]) => {
+      return typeof v === 'string' && v.length > 0;
+    }) as [string, string][];
+
+    // Iterate over each global function and save it to the instance store.
+    for (const [functionName, functionCode] of pairs) {
+      this.workflowTemplateFunctions[workflowTemplateId] ??= {};
+
+      try {
+        this.workflowTemplateFunctions[workflowTemplateId][functionName] = this.eval(functionCode, {
+          isAsync: functionCode.trim().startsWith('async'),
+        });
+
+        this.getLog().save(
+          'sandbox-global-function',
+          {
+            workflowTemplateId,
+            functionName,
+          },
+          'info',
+        );
+      } catch (error: any) {
+        this.getLog().save(
+          'sandbox-global-function-error',
+          {
+            workflowTemplateId,
+            functionName,
+            error: error.message,
+            code: functionCode,
+          },
+          'warn',
+        );
+      }
+    }
+  }
+
+  /**
+   * Create a true `isolated-vm` context bound to this sandbox's isolate.
+   * @returns {SandboxContext}
+   */
+  createContext(): SandboxContext {
+    return new SandboxContext(this);
+  }
+
+  /**
+   * Minify code by stripping comments and whitespace.
+   * @param {string} code - The code to minify.
+   * @returns {string} - Minified code without comments.
+   */
+  static minifyCode(code: string): string {
+    return code
+      .replace(/^\s*\/\/.*$/gm, '') // Remove single-line comments starting from the line beginning
+      .replace(/^\s*\/\*[\s\S]*?\*\//gm, '') // Remove multi-line comments starting from the line beginning
+      .trim();
+  }
+
+  /**
+   * Evaluate code within a sandbox.
+   * @param {string} code Code to execute.
+   * @param {EvalOptions} options
+   * @returns {any} Result.
+   */
+  eval(code: string, options: EvalOptions = {}): any {
+    const meta = getTraceMeta() || {};
+
+    if (typeof code !== 'string' || code.length === 0) {
+      return options.defaultValue;
+    }
+
+    const hash = crypto.createHash('sha1').update(code).update(JSON.stringify(options)).digest('base64url');
+    if (this.cache.has(hash)) {
+      return this.cache.get(hash);
+    }
+
+    options.global ??= {};
+    options.global[this.globalFunctionsObject] = { workflow: {} };
+    options.global.log = this.getSandboxLog({ ...options.meta, hash, workflowTemplateId: options.workflowTemplateId });
+
+    // Add workflow template global functions to the execution context.
+    const workflowTemplateId = options.workflowTemplateId || meta.workflowTemplateId;
+    if (workflowTemplateId) {
+      options.global[this.globalFunctionsObject].workflow = {
+        ...this.workflowTemplateFunctions[workflowTemplateId],
+      };
+    }
+
+    const globalContext = { ...this.defaultGlobals, ...options.global };
+
+    let transformedCode = Sandbox.minifyCode(code);
+    if (options.isAsync) {
+      const asyncFunctions = Object.entries(globalContext)
+        .filter(([, value]) => {
+          return typeof value === 'function' && (value as any).constructor.name === 'AsyncFunction';
+        })
+        .map(([key]) => key);
+
+      transformedCode = transformFunctionToAsync(transformedCode, asyncFunctions);
+    }
+
+    // Setup function with global context pulled from options.
+    const keys = Object.keys(globalContext);
+    const values = Object.values(globalContext);
+    const fn = new Function(...keys, `return ${transformedCode}`)(...values);
+    this.cache.set(hash, fn);
+    return fn;
+  }
+
+  /**
+   * Evaluate and run code with arguments within a sandbox.
+   * @param {string} code Code to execute.
+   * @param {any[]} args Arguments.
+   * @param {EvalOptions} options Additional evaluation options.
+   * @returns {any} Result.
+   */
+  evalWithArgs(code: string | undefined, args?: any[], options: EvalOptions = {}): any {
+    const meta = options.meta ?? {};
+
+    if (code === undefined && 'defaultValue' in options) {
+      return options.defaultValue;
+    } else if (code === undefined && options.throwOnUndefined) {
+      throw this.throwError(new Error('Code is undefined'), code, meta);
+    } else if (code === undefined) {
+      return undefined;
+    }
+
+    // Copy workflowTemplateId to meta if it exists in options.
+    if (options.workflowTemplateId && !meta.workflowTemplateId) {
+      meta.workflowTemplateId = options.workflowTemplateId;
+    }
+
+    try {
+      const time = Date.now();
+
+      // Temporary fix for old low code snippets.
+      if (options.isAsync && code.trim().startsWith('(') && !code.trim().startsWith('async') && /\bawait\b/.test(code)) {
+        code = `async ${code}`;
+      }
+
+      let isArrowFunction, arrowParams, acornError;
+      try {
+        const { body } = acorn.parse(code, { ecmaVersion: 2020 }) as any;
+        if (body[0].type === 'ExpressionStatement' && body[0].expression.type === 'ArrowFunctionExpression') {
+          isArrowFunction = true;
+          arrowParams = body[0].expression.params.map((param: any) => param.name);
+          if (isArrowFunction && Array.isArray(arrowParams) && args) {
+            args = args.slice(0, arrowParams.length);
+          }
+        }
+      } catch (error) {
+        acornError = error;
+      }
+
+      if (options.checkArrow && !isArrowFunction) {
+        return code;
+      } else if (acornError) {
+        throw acornError;
+      }
+
+      const fn = this.eval(code, options);
+
+      if (typeof fn !== 'function') {
+        if (!options.checkArrow) {
+          this.getLog().save('sandbox-warning', { ...meta, error: 'Function not found', acornError, code }, 'warn');
+        }
+        return fn;
+      }
+
+      if (this.config.logging) {
+        const result = fn(...(args || []));
+        this.getLog().save('sandbox-eval', { ...meta, isArrowFunction, arrowParams, duration: Date.now() - time });
+        return result;
+      } else {
+        return fn(...(args || []));
+      }
+    } catch (error) {
+      throw this.throwError(error, code, meta);
+    }
+  }
+
+  throwError(error: any, code: any, meta: any): Error {
+    this.getLog().save('sandbox-error', { ...meta, error: error.message, code }, 'error');
+
+    let errorMessage = `Sandbox error: "${error.message}"`;
+    if (meta.fn) {
+      errorMessage += ` in ${meta.fn}`;
+    }
+    if (meta.caller) {
+      errorMessage += ` called by ${meta.caller}`;
+    }
+
+    if (error.loc) {
+      const excerpt = code.split('\n')[error.loc.line - 1];
+      errorMessage += `\n  ${excerpt}\n  ${' '.repeat(error.loc.column)}^`;
+    }
+
+    return new Error(errorMessage);
+  }
+
+  /**
+   * Resolve the logger to use, defaulting to `global.log` for backwards compatibility
+   * with components that set it up as a process-wide singleton.
+   * @returns {SandboxLog}
+   */
+  private getLog(): SandboxLog {
+    if (this.config.getLog) {
+      return this.config.getLog();
+    }
+    return (global as any).log;
+  }
+
+  private getSandboxLog(meta: Record<string, any>): (data: any) => void {
+    return (data: any) => {
+      this.getLog().save('sandbox-log', { data, meta }, 'info');
+    };
+  }
+}
+
+export class SandboxContext {
+  sandbox: Sandbox;
+  context: vm.Context;
+  jail: vm.Reference;
+
+  constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+    this.context = sandbox.isolate.createContextSync();
+    this.jail = this.context.global;
+  }
+
+  set(name: string, value: any): SandboxContext {
+    this.jail.setSync(name, new vm.Reference(value));
+    return this;
+  }
+
+  eval(code: string): any {
+    return this.context.evalSync(code);
+  }
+}
+
+/**
+ * Transform a function's source to `async`, awaiting calls to any of the given async
+ * globals so a caller can pass a synchronous-looking arrow function that calls async
+ * helpers without having to write `async`/`await` itself.
+ * @param {string} functionString Function source code.
+ * @param {string[]} allowedAsyncFunctions Names of async globals referenced by the function.
+ * @returns {string} Transformed function source.
+ */
+function transformFunctionToAsync(functionString: string, allowedAsyncFunctions: string[] = []): string {
+  const isFunctionStringContainsAsyncFunction = allowedAsyncFunctions.some(
+    (v) => functionString.includes(v) && !functionString.includes(`await ${v}`),
+  );
+
+  // Return as is if async function not used.
+  if (!isFunctionStringContainsAsyncFunction) {
+    return functionString;
+  }
+
+  // Transform to async.
+  let asyncFunctionString = functionString;
+  if (!asyncFunctionString.startsWith('async')) {
+    asyncFunctionString = `async ${asyncFunctionString}`;
+  }
+  for (const asyncFunctionInside of allowedAsyncFunctions) {
+    asyncFunctionString = asyncFunctionString.replace(new RegExp(`(?<!\\.)\\b${asyncFunctionInside}\\b`, 'g'), `await ${asyncFunctionInside}`);
+  }
+
+  return asyncFunctionString;
+}
+
+/**
+ * Get md5 hash.
+ * @param {string} data Data.
+ * @returns {string}
+ */
+function getMd5Hash(data: string): string {
+  return crypto.createHash('md5').update(data).digest('hex');
+}
+
+/**
+ * Get sha256 hash.
+ * @param {string} data Data.
+ * @returns {string}
+ */
+function getSha256Hash(data: string): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Get sha512 hash.
+ * @param {string} data Data.
+ * @param {object} [options] Options.
+ * @param {string} [options.hmac] HMAC secret.
+ * @returns {string}
+ */
+function getSha512Hash(data: string, options?: { hmac?: string }): string {
+  if (options?.hmac) {
+    return crypto.createHmac('sha512', options.hmac).update(data).digest('hex');
+  }
+  return crypto.createHash('sha512').update(data).digest('hex');
+}
+
+/**
+ * Base64 decode.
+ * @param {string} data Base64 string.
+ * @returns {string} RAW string.
+ */
+function base64Decode(data: string): string {
+  return Buffer.from(data, 'base64').toString('utf8');
+}
+
+/**
+ * Base64 encode.
+ * @param {string} rawString RAW string.
+ * @param {BufferEncoding} [rawStringEncoding] RAW string encoding. Default value: `utf8`.
+ * @returns {string} Base64 string.
+ */
+function base64Encode(rawString: string = '', rawStringEncoding: BufferEncoding = 'utf8'): string {
+  return Buffer.from(rawString, rawStringEncoding).toString('base64');
+}
+
+/**
+ * Convert data to base64.
+ * @param {string} data Data.
+ * @returns {string} Base64 string.
+ */
+function toBase64(data: string): string {
+  return Buffer.from(data).toString('base64');
+}

--- a/packages/back-core/src/common/sandbox.ts
+++ b/packages/back-core/src/common/sandbox.ts
@@ -14,6 +14,46 @@ const { randomUUID } = crypto;
 const DEFAULT_GLOBAL_FUNCTIONS_OBJECT = '$';
 const DEFAULT_LRU_MAX = 1000; // 1000 items
 
+/** Marks a host wrapper function (built by `compileInIsolatedVm` for async code) as
+ * promise-returning, so nesting it as a global into another isolate — as happens when a
+ * compiled workflow template function is exposed under `$.workflow` — bridges it correctly
+ * even though the wrapper itself isn't declared `async`. */
+const ASYNC_BRIDGE_MARKER = Symbol('isolatedVmAsyncBridge');
+
+/**
+ * Whether a function value is (or behaves like) an `AsyncFunction`. TypeScript targets at or
+ * below ES2016 (this repo builds at ES6) downlevel `async`/`await` into a plain function
+ * wrapping a generator via the `__awaiter` helper, which loses the native `AsyncFunction`
+ * constructor — so a TypeScript-authored async global doesn't pass a bare `constructor.name`
+ * check. Detect that shape from its source text as a fallback, alongside `ASYNC_BRIDGE_MARKER`.
+ * @param {any} value Value to check.
+ * @returns {boolean}
+ */
+function isAsyncFunctionValue(value: any): boolean {
+  if (typeof value !== 'function') return false;
+  if (value.constructor?.name === 'AsyncFunction') return true;
+  if (value[ASYNC_BRIDGE_MARKER] === true) return true;
+  return /\b__awaiter\(/.test(Function.prototype.toString.call(value));
+}
+
+/** Sandbox globals that can't be safely bridged into an `isolated-vm` isolate: they are rich
+ * library namespaces (native bindings, or objects whose methods return further class instances
+ * that lose their prototype once copied across the isolation boundary), rather than plain
+ * functions operating on cloneable data. They remain available under the default `function`
+ * isolation level. */
+const ISOLATED_VM_UNSUPPORTED_GLOBALS = new Set(['_', 'iconv', 'moment', 'crypto']);
+
+/**
+ * How evaluated code is isolated from the host process:
+ * - `function` (default): compiled with `new Function(...)`. Fast, and gives every default
+ *   global (including rich libraries like `_`/`moment`) full fidelity, but code runs in the
+ *   same V8 realm as the host — it can reach and mutate the host's global object.
+ * - `isolated-vm`: compiled and run inside a real V8 isolate (via `SandboxContext`). Code
+ *   cannot touch the host realm at all, but only plain functions and JSON-safe data can cross
+ *   the isolation boundary, so `_`, `iconv`, `moment` and `crypto` are not available.
+ */
+export type SandboxIsolationLevel = 'function' | 'isolated-vm';
+
 /**
  * Minimal structural shape for the log object each component exposes on `global.log`.
  * Consumers may instead pass a `getLog` function in the sandbox config to avoid
@@ -32,6 +72,8 @@ export interface SandboxConfig {
   logging?: boolean;
   /** Returns the logger to use. Defaults to reading `global.log`. */
   getLog?: () => SandboxLog;
+  /** How evaluated code is isolated from the host process. Default: 'function'. */
+  isolationLevel?: SandboxIsolationLevel;
   [key: string]: any;
 }
 
@@ -276,20 +318,83 @@ export class Sandbox {
     let transformedCode = Sandbox.minifyCode(code);
     if (options.isAsync) {
       const asyncFunctions = Object.entries(globalContext)
-        .filter(([, value]) => {
-          return typeof value === 'function' && (value as any).constructor.name === 'AsyncFunction';
-        })
+        .filter(([, value]) => isAsyncFunctionValue(value))
         .map(([key]) => key);
 
       transformedCode = transformFunctionToAsync(transformedCode, asyncFunctions);
     }
 
-    // Setup function with global context pulled from options.
-    const keys = Object.keys(globalContext);
-    const values = Object.values(globalContext);
-    const fn = new Function(...keys, `return ${transformedCode}`)(...values);
+    // Compile the code under the configured isolation level.
+    const fn =
+      this.config.isolationLevel === 'isolated-vm'
+        ? this.compileInIsolatedVm(transformedCode, globalContext, !!options.isAsync)
+        : new Function(...Object.keys(globalContext), `return ${transformedCode}`)(...Object.values(globalContext));
+
     this.cache.set(hash, fn);
     return fn;
+  }
+
+  /**
+   * Compile code inside a real `isolated-vm` context so it cannot reach the host's global
+   * object or Node built-ins. Only plain functions and JSON-safe data can cross the isolation
+   * boundary: functions are bridged as callables backed by an `isolated-vm` Reference (invoked
+   * synchronously via `applySync`, or asynchronously via `apply` with `{ result: { promise:
+   * true } }` for `AsyncFunction`s), arguments/return values are copied by value, and rich
+   * library namespaces in `ISOLATED_VM_UNSUPPORTED_GLOBALS` are omitted entirely.
+   * @param {string} code Minified (and, if async, already transformed) code to execute.
+   * @param {object} globalContext Globals to expose to the evaluated code.
+   * @param {boolean} isAsync Whether the top-level code is an async function.
+   * @returns {(...args: any[]) => any} Callable compiled function.
+   */
+  private compileInIsolatedVm(code: string, globalContext: Record<string, any>, isAsync: boolean): (...args: any[]) => any {
+    const context = this.createContext();
+    const refs: { refName: string; value: any }[] = [];
+
+    const buildExpr = (value: any, seen: WeakSet<object>): string => {
+      if (typeof value === 'function') {
+        const refName = `__ref_${refs.length}`;
+        const isAsyncFn = isAsyncFunctionValue(value);
+        refs.push({ refName, value });
+        const applyExpr = isAsyncFn
+          ? `${refName}.apply(undefined, args, { arguments: { copy: true }, result: { promise: true, copy: true } })`
+          : `${refName}.applySync(undefined, args, { arguments: { copy: true }, result: { copy: true } })`;
+        return `function() { var args = Array.prototype.slice.call(arguments); return ${applyExpr}; }`;
+      }
+
+      if (value !== null && typeof value === 'object') {
+        // Guard against cycles in caller-supplied globals (default globals are cycle-free).
+        if (seen.has(value)) return 'undefined';
+        seen.add(value);
+        if (Array.isArray(value)) {
+          return `[${value.map((v) => buildExpr(v, seen)).join(', ')}]`;
+        }
+        const entries = Object.entries(value).map(([key, v]) => `${JSON.stringify(key)}: ${buildExpr(v, seen)}`);
+        return `{${entries.join(', ')}}`;
+      }
+
+      return JSON.stringify(value) ?? 'undefined';
+    };
+
+    const assignments = Object.entries(globalContext)
+      .filter(([name]) => !ISOLATED_VM_UNSUPPORTED_GLOBALS.has(name))
+      .map(([name, value]) => `var ${name} = ${buildExpr(value, new WeakSet())};`)
+      .join('\n');
+
+    for (const { refName, value } of refs) {
+      context.jail.setSync(refName, new vm.Reference(value));
+    }
+
+    const wrappedCode = `(function() {\n${assignments}\nreturn ${code};\n})()`;
+
+    if (isAsync) {
+      const ref: any = context.context.evalSync(wrappedCode, { reference: true } as any);
+      const wrapped = (...args: any[]): Promise<any> =>
+        ref.apply(undefined, args, { arguments: { copy: true }, result: { promise: true, copy: true } });
+      (wrapped as any)[ASYNC_BRIDGE_MARKER] = true;
+      return wrapped;
+    }
+
+    return context.context.evalSync(wrappedCode);
   }
 
   /**

--- a/packages/back-core/src/common/sandbox.ts
+++ b/packages/back-core/src/common/sandbox.ts
@@ -20,20 +20,39 @@ const DEFAULT_LRU_MAX = 1000; // 1000 items
  * even though the wrapper itself isn't declared `async`. */
 const ASYNC_BRIDGE_MARKER = Symbol('isolatedVmAsyncBridge');
 
+/** A host wrapper function produced by `compileInIsolatedVm` for async code, tagged with
+ * `ASYNC_BRIDGE_MARKER` so it can be recognized as promise-returning when nested as a global
+ * into another isolate. */
+interface AsyncBridgeFunction {
+  (...args: unknown[]): Promise<unknown>;
+  [ASYNC_BRIDGE_MARKER]?: true;
+}
+
 /**
  * Whether a function value is (or behaves like) an `AsyncFunction`. TypeScript targets at or
  * below ES2016 (this repo builds at ES6) downlevel `async`/`await` into a plain function
  * wrapping a generator via the `__awaiter` helper, which loses the native `AsyncFunction`
  * constructor — so a TypeScript-authored async global doesn't pass a bare `constructor.name`
  * check. Detect that shape from its source text as a fallback, alongside `ASYNC_BRIDGE_MARKER`.
- * @param {any} value Value to check.
+ * @param {unknown} value Value to check.
  * @returns {boolean}
  */
-function isAsyncFunctionValue(value: any): boolean {
+function isAsyncFunctionValue(value: unknown): boolean {
   if (typeof value !== 'function') return false;
   if (value.constructor?.name === 'AsyncFunction') return true;
-  if (value[ASYNC_BRIDGE_MARKER] === true) return true;
+  if ((value as AsyncBridgeFunction)[ASYNC_BRIDGE_MARKER] === true) return true;
   return /\b__awaiter\(/.test(Function.prototype.toString.call(value));
+}
+
+/** Structural shape of a thrown value that looks like an `Error` (has a string `.message`,
+ * and optionally a parser-style `.loc`), without requiring `instanceof Error` — a real `Error`
+ * thrown inside an `isolated-vm` isolate crosses back as an object of this shape but belongs to
+ * a different V8 realm, so `instanceof` against the host's own `Error` constructor fails.
+ * @param {unknown} error Value to check.
+ * @returns {boolean}
+ */
+function isErrorLike(error: unknown): error is { message: string; loc?: { line: number; column: number } } {
+  return typeof error === 'object' && error !== null && typeof (error as { message?: unknown }).message === 'string';
 }
 
 /** Sandbox globals that can't be safely bridged into an `isolated-vm` isolate: they are rich
@@ -44,15 +63,21 @@ function isAsyncFunctionValue(value: any): boolean {
 const ISOLATED_VM_UNSUPPORTED_GLOBALS = new Set(['_', 'iconv', 'moment', 'crypto']);
 
 /**
- * How evaluated code is isolated from the host process:
- * - `function` (default): compiled with `new Function(...)`. Fast, and gives every default
- *   global (including rich libraries like `_`/`moment`) full fidelity, but code runs in the
- *   same V8 realm as the host — it can reach and mutate the host's global object.
- * - `isolated-vm`: compiled and run inside a real V8 isolate (via `SandboxContext`). Code
- *   cannot touch the host realm at all, but only plain functions and JSON-safe data can cross
- *   the isolation boundary, so `_`, `iconv`, `moment` and `crypto` are not available.
+ * How evaluated code is isolated from the host process.
  */
-export type SandboxIsolationLevel = 'function' | 'isolated-vm';
+export enum SandboxIsolationLevel {
+  /** Compiled with `new Function(...)`. Fast, and gives every default global (including rich
+   * libraries like `_`/`moment`) full fidelity, but code runs in the same V8 realm as the host
+   * — it can reach and mutate the host's global object. This is the default. */
+  Function = 'function',
+  /** Compiled and run inside a real V8 isolate (via `SandboxContext`). Code cannot touch the
+   * host realm at all, but only plain functions and JSON-safe data can cross the isolation
+   * boundary, so `_`, `iconv`, `moment` and `crypto` are not available. */
+  IsolatedVm = 'isolated-vm',
+}
+
+/** Log levels used by `Sandbox`'s own diagnostic `save()` calls. */
+export type SandboxLogLevel = 'info' | 'warn' | 'error';
 
 /**
  * Minimal structural shape for the log object each component exposes on `global.log`.
@@ -60,7 +85,7 @@ export type SandboxIsolationLevel = 'function' | 'isolated-vm';
  * depending on a process-wide global.
  */
 export interface SandboxLog {
-  save(event: string, data: Record<string, any>, level?: string): void;
+  save(event: string, data: Record<string, unknown>, level?: SandboxLogLevel): void;
 }
 
 export interface SandboxConfig {
@@ -72,14 +97,14 @@ export interface SandboxConfig {
   logging?: boolean;
   /** Returns the logger to use. Defaults to reading `global.log`. */
   getLog?: () => SandboxLog;
-  /** How evaluated code is isolated from the host process. Default: 'function'. */
+  /** How evaluated code is isolated from the host process. Default: `SandboxIsolationLevel.Function`. */
   isolationLevel?: SandboxIsolationLevel;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface EvalOptions {
   /** Extra globals to expose to the evaluated code, merged over the sandbox defaults. */
-  global?: Record<string, any>;
+  global?: Record<string, unknown>;
   /** Evaluate code as an async function, awaiting any async globals it calls. */
   isAsync?: boolean;
   /** Throw an error if code is undefined. */
@@ -89,10 +114,10 @@ export interface EvalOptions {
   /** Workflow template ID whose global functions should be exposed as `$.workflow`. */
   workflowTemplateId?: string | number;
   /** Default value to return if code is empty/undefined. */
-  defaultValue?: any;
+  defaultValue?: unknown;
   /** Meta data for logging. */
-  meta?: Record<string, any>;
-  [key: string]: any;
+  meta?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 /**
@@ -108,9 +133,9 @@ export class Sandbox {
   config: SandboxConfig;
   isolate: vm.Isolate;
   globalFunctionsObject: string;
-  defaultGlobals: Record<string, any>;
-  cache: LRUCache<string, any>;
-  workflowTemplateFunctions: Record<string | number, Record<string, any>>;
+  defaultGlobals: Record<string, unknown>;
+  cache: LRUCache<string, unknown>;
+  workflowTemplateFunctions: Record<string | number, Record<string, unknown>>;
 
   /**
    * Get the singleton instance of the Sandbox.
@@ -166,10 +191,10 @@ export class Sandbox {
    * Register a new default global for evaluated code. Fails if the name is already taken,
    * so components don't silently shadow one of the built-in helpers or each other's globals.
    * @param {string} name Global name.
-   * @param {any} value Global value.
+   * @param {unknown} value Global value.
    * @returns {Sandbox}
    */
-  addGlobal(name: string, value: any): Sandbox {
+  addGlobal(name: string, value: unknown): Sandbox {
     if (typeof name !== 'string' || name.length === 0) {
       throw new Error('Global name must be a non-empty string');
     }
@@ -204,7 +229,7 @@ export class Sandbox {
       const globalFunctions = workflowTemplate.data?.globalFunctions || {};
 
       if (typeof globalFunctions !== 'object') {
-        this.getLog().save(
+        this.log.save(
           'sandbox-warning',
           {
             workflowTemplateId: workflowTemplate.id,
@@ -225,7 +250,7 @@ export class Sandbox {
    * @param {string|number} workflowTemplateId Workflow template ID.
    * @param {object} globalFunctions Map of function name to function source code.
    */
-  updateWorkflowTemplateFunctions(workflowTemplateId: string | number, globalFunctions: Record<string, any>): void {
+  updateWorkflowTemplateFunctions(workflowTemplateId: string | number, globalFunctions: Record<string, unknown>): void {
     // Filter out empty strings.
     const pairs = Object.entries(globalFunctions || {}).filter(([, v]) => {
       return typeof v === 'string' && v.length > 0;
@@ -240,7 +265,7 @@ export class Sandbox {
           isAsync: functionCode.trim().startsWith('async'),
         });
 
-        this.getLog().save(
+        this.log.save(
           'sandbox-global-function',
           {
             workflowTemplateId,
@@ -248,13 +273,13 @@ export class Sandbox {
           },
           'info',
         );
-      } catch (error: any) {
-        this.getLog().save(
+      } catch (error) {
+        this.log.save(
           'sandbox-global-function-error',
           {
             workflowTemplateId,
             functionName,
-            error: error.message,
+            error: error instanceof Error ? error.message : String(error),
             code: functionCode,
           },
           'warn',
@@ -302,15 +327,14 @@ export class Sandbox {
     }
 
     options.global ??= {};
-    options.global[this.globalFunctionsObject] = { workflow: {} };
+    const workflowScope: { workflow: Record<string, unknown> } = { workflow: {} };
+    options.global[this.globalFunctionsObject] = workflowScope;
     options.global.log = this.getSandboxLog({ ...options.meta, hash, workflowTemplateId: options.workflowTemplateId });
 
     // Add workflow template global functions to the execution context.
     const workflowTemplateId = options.workflowTemplateId || meta.workflowTemplateId;
     if (workflowTemplateId) {
-      options.global[this.globalFunctionsObject].workflow = {
-        ...this.workflowTemplateFunctions[workflowTemplateId],
-      };
+      workflowScope.workflow = { ...this.workflowTemplateFunctions[workflowTemplateId] };
     }
 
     const globalContext = { ...this.defaultGlobals, ...options.global };
@@ -326,7 +350,7 @@ export class Sandbox {
 
     // Compile the code under the configured isolation level.
     const fn =
-      this.config.isolationLevel === 'isolated-vm'
+      this.config.isolationLevel === SandboxIsolationLevel.IsolatedVm
         ? this.compileInIsolatedVm(transformedCode, globalContext, !!options.isAsync)
         : new Function(...Object.keys(globalContext), `return ${transformedCode}`)(...Object.values(globalContext));
 
@@ -346,11 +370,11 @@ export class Sandbox {
    * @param {boolean} isAsync Whether the top-level code is an async function.
    * @returns {(...args: any[]) => any} Callable compiled function.
    */
-  private compileInIsolatedVm(code: string, globalContext: Record<string, any>, isAsync: boolean): (...args: any[]) => any {
+  private compileInIsolatedVm(code: string, globalContext: Record<string, unknown>, isAsync: boolean): (...args: any[]) => any {
     const context = this.createContext();
-    const refs: { refName: string; value: any }[] = [];
+    const refs: { refName: string; value: unknown }[] = [];
 
-    const buildExpr = (value: any, seen: WeakSet<object>): string => {
+    const buildExpr = (value: unknown, seen: WeakSet<object>): string => {
       if (typeof value === 'function') {
         const refName = `__ref_${refs.length}`;
         const isAsyncFn = isAsyncFunctionValue(value);
@@ -387,10 +411,10 @@ export class Sandbox {
     const wrappedCode = `(function() {\n${assignments}\nreturn ${code};\n})()`;
 
     if (isAsync) {
-      const ref: any = context.context.evalSync(wrappedCode, { reference: true } as any);
-      const wrapped = (...args: any[]): Promise<any> =>
+      const ref = context.context.evalSync(wrappedCode, { reference: true });
+      const wrapped: AsyncBridgeFunction = (...args) =>
         ref.apply(undefined, args, { arguments: { copy: true }, result: { promise: true, copy: true } });
-      (wrapped as any)[ASYNC_BRIDGE_MARKER] = true;
+      wrapped[ASYNC_BRIDGE_MARKER] = true;
       return wrapped;
     }
 
@@ -428,12 +452,14 @@ export class Sandbox {
         code = `async ${code}`;
       }
 
-      let isArrowFunction, arrowParams, acornError;
+      let isArrowFunction: boolean | undefined;
+      let arrowParams: Array<string | undefined> | undefined;
+      let acornError: unknown;
       try {
-        const { body } = acorn.parse(code, { ecmaVersion: 2020 }) as any;
-        if (body[0].type === 'ExpressionStatement' && body[0].expression.type === 'ArrowFunctionExpression') {
+        const [firstStatement] = acorn.parse(code, { ecmaVersion: 2020 }).body;
+        if (firstStatement?.type === 'ExpressionStatement' && firstStatement.expression.type === 'ArrowFunctionExpression') {
           isArrowFunction = true;
-          arrowParams = body[0].expression.params.map((param: any) => param.name);
+          arrowParams = firstStatement.expression.params.map((param) => ('name' in param ? param.name : undefined));
           if (isArrowFunction && Array.isArray(arrowParams) && args) {
             args = args.slice(0, arrowParams.length);
           }
@@ -452,14 +478,14 @@ export class Sandbox {
 
       if (typeof fn !== 'function') {
         if (!options.checkArrow) {
-          this.getLog().save('sandbox-warning', { ...meta, error: 'Function not found', acornError, code }, 'warn');
+          this.log.save('sandbox-warning', { ...meta, error: 'Function not found', acornError, code }, 'warn');
         }
         return fn;
       }
 
       if (this.config.logging) {
         const result = fn(...(args || []));
-        this.getLog().save('sandbox-eval', { ...meta, isArrowFunction, arrowParams, duration: Date.now() - time });
+        this.log.save('sandbox-eval', { ...meta, isArrowFunction, arrowParams, duration: Date.now() - time });
         return result;
       } else {
         return fn(...(args || []));
@@ -469,40 +495,46 @@ export class Sandbox {
     }
   }
 
-  throwError(error: any, code: any, meta: any): Error {
-    this.getLog().save('sandbox-error', { ...meta, error: error.message, code }, 'error');
+  throwError(error: unknown, code: string | undefined, meta: Record<string, unknown>): Error {
+    // Duck-type rather than `instanceof Error`: an error thrown inside an `isolated-vm` isolate
+    // crosses back as an object shaped like an Error, but isn't recognized by the host's own
+    // Error constructor since it belongs to a different V8 realm.
+    const errorLike = isErrorLike(error) ? error : undefined;
+    const message = errorLike?.message ?? String(error);
+    const loc = errorLike?.loc;
 
-    let errorMessage = `Sandbox error: "${error.message}"`;
+    this.log.save('sandbox-error', { ...meta, error: message, code }, 'error');
+
+    let errorMessage = `Sandbox error: "${message}"`;
     if (meta.fn) {
-      errorMessage += ` in ${meta.fn}`;
+      errorMessage += ` in ${String(meta.fn)}`;
     }
     if (meta.caller) {
-      errorMessage += ` called by ${meta.caller}`;
+      errorMessage += ` called by ${String(meta.caller)}`;
     }
 
-    if (error.loc) {
-      const excerpt = code.split('\n')[error.loc.line - 1];
-      errorMessage += `\n  ${excerpt}\n  ${' '.repeat(error.loc.column)}^`;
+    if (loc && typeof code === 'string') {
+      const excerpt = code.split('\n')[loc.line - 1];
+      errorMessage += `\n  ${excerpt}\n  ${' '.repeat(loc.column)}^`;
     }
 
     return new Error(errorMessage);
   }
 
   /**
-   * Resolve the logger to use, defaulting to `global.log` for backwards compatibility
-   * with components that set it up as a process-wide singleton.
-   * @returns {SandboxLog}
+   * The logger to use, defaulting to `global.log` for backwards compatibility with components
+   * that set it up as a process-wide singleton.
    */
-  private getLog(): SandboxLog {
+  private get log(): SandboxLog {
     if (this.config.getLog) {
       return this.config.getLog();
     }
-    return (global as any).log;
+    return (global as unknown as { log: SandboxLog }).log;
   }
 
-  private getSandboxLog(meta: Record<string, any>): (data: any) => void {
-    return (data: any) => {
-      this.getLog().save('sandbox-log', { data, meta }, 'info');
+  private getSandboxLog(meta: Record<string, unknown>): (data: unknown) => void {
+    return (data: unknown) => {
+      this.log.save('sandbox-log', { data, meta }, 'info');
     };
   }
 }
@@ -518,7 +550,7 @@ export class SandboxContext {
     this.jail = this.context.global;
   }
 
-  set(name: string, value: any): SandboxContext {
+  set(name: string, value: unknown): SandboxContext {
     this.jail.setSync(name, new vm.Reference(value));
     return this;
   }

--- a/packages/back-core/src/index.ts
+++ b/packages/back-core/src/index.ts
@@ -5,3 +5,4 @@ export * from './common/log/helpers/cutLongStrings';
 export * from './common/log/helpers/sensitiveReplace';
 export * from './common/app_info';
 export * from './common/async_local_storage';
+export * from './common/sandbox';


### PR DESCRIPTION
Adds a `Sandbox` class to `@liquio/back-core`, consolidating the near-identical
low-code eval implementations currently duplicated across the `task`,
`admin-api`, `event`, `gateway`, and `persist-link` components (`register`'s
`Isolation` class is unrelated and untouched — it serves a narrower purpose).

- `eval`/`evalWithArgs`, workflow-template global functions, `addGlobal`,
  and the default crypto/hash/base64 helpers, matching the union of behavior
  across all five component implementations.
- New `isolationLevel` option (`SandboxIsolationLevel.Function` — the
  existing `new Function(...)`-based behavior — or `SandboxIsolationLevel.IsolatedVm`,
  which runs code inside a real V8 isolate via `isolated-vm` so it can't
  reach or mutate the host's global object). Plain functions and JSON-safe
  data are bridged across the isolation boundary; rich library namespaces
  (`_`, `iconv`, `moment`, `crypto`) are intentionally unavailable under
  `IsolatedVm` since their return values lose their prototype once copied.
- Along the way, fixed a pre-existing bug in the shared async-global
  detection: this repo's ES6 build target downlevels `async`/`await` via
  TypeScript's `__awaiter` helper, which strips the native `AsyncFunction`
  constructor that detection relied on — the `IsolatedVm` level is the first
  thing to actually depend on that detection being correct.
- Typing pass: `isolationLevel` is an exported enum rather than a bare
  string union, and `any` is replaced with `unknown` (plus a few narrower
  types/guards) across `SandboxConfig`, `EvalOptions`, `SandboxLog`, and
  related `Sandbox` members.