### PR TITLE
fix(task-payone-plugin): base payment success on paymentStatusCategory

### DIFF
--- a/packages/task-payone-plugin/package-lock.json
+++ b/packages/task-payone-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liquio/task-payone-plugin",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@liquio/task-payone-plugin",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@liquio/plugin-sdk": "^0.1.5",

--- a/packages/task-payone-plugin/package.json
+++ b/packages/task-payone-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquio/task-payone-plugin",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "description": "PAYONE Platform payment provider plugin for components/task, built on @liquio/plugin-sdk",
   "main": "dist/index.js",

--- a/packages/task-payone-plugin/src/payone_provider.spec.ts
+++ b/packages/task-payone-plugin/src/payone_provider.spec.ts
@@ -670,7 +670,9 @@ describe("PayoneProvider", () => {
       it("resolves documentId/paymentControlPath/taskId from the payment transaction record when they aren't present on the callback", async () => {
         getCheckoutRequestMock.mockResolvedValue({
           checkoutStatus: "COMPLETED",
-          statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
+          statusOutput: {
+            paymentStatus: PayonePaymentStatusCategory.Successful,
+          },
           references: { merchantReference: "order-42" },
         });
         const resolvePaymentTransactionMock = jest.fn().mockResolvedValue({

--- a/packages/task-payone-plugin/src/payone_provider.spec.ts
+++ b/packages/task-payone-plugin/src/payone_provider.spec.ts
@@ -87,7 +87,12 @@ class ApiErrorResponseException extends Error {
 }
 
 import { PayoneProvider } from "./payone_provider";
-import { PayoneOptions, PayoneResolvedPaymentData } from "./types";
+import {
+  PayoneCheckoutStatus,
+  PayoneOptions,
+  PayonePaymentStatusCategory,
+  PayoneResolvedPaymentData,
+} from "./types";
 
 describe("PayoneProvider", () => {
   const context: PluginContext = {
@@ -210,6 +215,7 @@ describe("PayoneProvider", () => {
       // params the browser redirect carries.
       getCheckoutRequestMock.mockResolvedValue({
         checkoutStatus: StatusCheckout.COMPLETED,
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
         references: { merchantReference: resolvedData.orderId },
       });
       const queryParamsObject = Object.fromEntries(
@@ -470,7 +476,7 @@ describe("PayoneProvider", () => {
         checkoutStatus: "COMPLETED",
         references: { merchantReference: "order-42" },
         paymentExecutions: [{ paymentExecutionId: "exec-1" }],
-        statusOutput: { paymentStatus: "PAYMENT_COMPLETED" },
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
       });
 
       const provider = new PayoneProvider(context, options);
@@ -495,11 +501,42 @@ describe("PayoneProvider", () => {
           order_id: "order-42",
           commerceCaseId: "commerce-case-1",
           checkoutId: "checkout-1",
-          checkoutStatus: "PAYMENT_CREATED",
-          paymentStatus: "PAYMENT_COMPLETED",
+          checkoutStatus: PayoneCheckoutStatus.PaymentCreated,
+          paymentStatus: PayonePaymentStatusCategory.Successful,
           checkPrevTransaction: false,
         },
       });
+    });
+
+    it("returns a failure shape for a completed checkout whose payment was declined (checkout-level status alone must not imply success)", async () => {
+      // Regression test: PAYONE's hosted-checkout status reaches "COMPLETED" (translated to
+      // "PAYMENT_CREATED" by the SDK) once a payment object exists, regardless of whether that
+      // payment was authorized or rejected - the real outcome is `paymentStatusCategory`.
+      getCheckoutRequestMock.mockResolvedValue({
+        commerceCaseId: "commerce-case-1",
+        checkoutId: "checkout-1",
+        checkoutStatus: "COMPLETED",
+        references: { merchantReference: "order-42" },
+        paymentExecutions: [{ paymentExecutionId: "exec-1" }],
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Rejected },
+      });
+
+      const provider = new PayoneProvider(context, options);
+      const result = await provider.handleStatus(
+        "",
+        options,
+        "success",
+        identifyingParams,
+        {},
+      );
+
+      expect(result.status).toEqual({ isSuccess: false });
+      expect(result.extraData.checkoutStatus).toBe(
+        PayoneCheckoutStatus.PaymentCreated,
+      );
+      expect(result.extraData.paymentStatus).toBe(
+        PayonePaymentStatusCategory.Rejected,
+      );
     });
 
     it("re-queries PAYONE and returns a failure shape for a still-open/non-terminal checkout, never trusting the incoming status", async () => {
@@ -568,7 +605,10 @@ describe("PayoneProvider", () => {
     });
 
     it("parses a JSON string webhook body (POST case) the same way as query params", async () => {
-      getCheckoutRequestMock.mockResolvedValue({ checkoutStatus: "BILLED" });
+      getCheckoutRequestMock.mockResolvedValue({
+        checkoutStatus: "BILLED",
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
+      });
 
       const provider = new PayoneProvider(context, options);
       const result = await provider.handleStatus(
@@ -587,7 +627,10 @@ describe("PayoneProvider", () => {
     });
 
     it("identifies the checkout directly from `data` for the checkPrevTransaction re-check path (no query params)", async () => {
-      getCheckoutRequestMock.mockResolvedValue({ checkoutStatus: "COMPLETED" });
+      getCheckoutRequestMock.mockResolvedValue({
+        checkoutStatus: "COMPLETED",
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
+      });
 
       const provider = new PayoneProvider(context, options);
       const result = await provider.handleStatus(
@@ -627,6 +670,7 @@ describe("PayoneProvider", () => {
       it("resolves documentId/paymentControlPath/taskId from the payment transaction record when they aren't present on the callback", async () => {
         getCheckoutRequestMock.mockResolvedValue({
           checkoutStatus: "COMPLETED",
+          statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
           references: { merchantReference: "order-42" },
         });
         const resolvePaymentTransactionMock = jest.fn().mockResolvedValue({
@@ -786,7 +830,7 @@ describe("PayoneProvider", () => {
     it("re-queries the hosted checkout and returns a success shape", async () => {
       getCheckoutRequestMock.mockResolvedValue({
         checkoutStatus: "COMPLETED",
-        statusOutput: { paymentStatus: "PAYMENT_COMPLETED" },
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
         references: { merchantReference: "order-42" },
       });
 
@@ -804,8 +848,8 @@ describe("PayoneProvider", () => {
       expect(result).toEqual({
         isSuccess: true,
         checkoutId: "checkout-1",
-        hostedCheckoutStatus: "PAYMENT_CREATED",
-        paymentStatus: "PAYMENT_COMPLETED",
+        hostedCheckoutStatus: PayoneCheckoutStatus.PaymentCreated,
+        paymentStatus: PayonePaymentStatusCategory.Successful,
         orderId: "order-42",
       });
     });

--- a/packages/task-payone-plugin/src/payone_provider.ts
+++ b/packages/task-payone-plugin/src/payone_provider.ts
@@ -9,6 +9,7 @@ import { init } from "onlinepayments-sdk-nodejs";
 import {
   PayoneCalculatedPaymentData,
   PayoneOptions,
+  PayonePaymentStatusCategory,
   PayoneResolvedPaymentData,
   PayoneStatusInfo,
 } from "./types";
@@ -365,7 +366,15 @@ export class PayoneProvider extends TaskPaymentProvider<PayoneOptions> {
       throw this.translateSdkError(error);
     }
 
-    const isSuccess = checkout.status === "PAYMENT_CREATED";
+    // `checkout.status === "PAYMENT_CREATED"` is NOT a success indicator - per PAYONE's own
+    // status reference (https://developer.payone.com/en/integration/api-developer-guide/statuses),
+    // that hosted-checkout-level status is reached for both approved and declined payments alike
+    // ("can occur alongside declined payments when examining the nested createdPaymentOutput
+    // properties"). The actual outcome is `createdPaymentOutput.paymentStatusCategory`
+    // (SUCCESSFUL / REJECTED / STATUS_UNKNOWN).
+    const isSuccess =
+      checkout.createdPaymentOutput?.paymentStatusCategory ===
+      PayonePaymentStatusCategory.Successful;
     const payment = checkout.createdPaymentOutput?.payment;
 
     // `checkPrevTransaction` (per `document.ts#calculatePayment`'s only caller of this path with
@@ -597,7 +606,12 @@ export class PayoneProvider extends TaskPaymentProvider<PayoneOptions> {
       if (!response.isSuccess) throw this.formatSdkResponseError(response);
       const checkout = response.body;
       const payment = checkout.createdPaymentOutput?.payment;
-      const isSuccess = checkout.status === "PAYMENT_CREATED";
+      // See the matching comment in `handleStatus` above: checkout-level status reaching
+      // "PAYMENT_CREATED" does not imply the payment was approved - `paymentStatusCategory` is
+      // the actual outcome.
+      const isSuccess =
+        checkout.createdPaymentOutput?.paymentStatusCategory ===
+        PayonePaymentStatusCategory.Successful;
 
       return {
         isSuccess,

--- a/packages/task-payone-plugin/src/types.ts
+++ b/packages/task-payone-plugin/src/types.ts
@@ -5,6 +5,34 @@ import type {
 } from "@liquio/plugin-sdk";
 
 /**
+ * `GetHostedCheckoutResponse.status` values (PAYONE Commerce Platform hosted-checkout-level
+ * status - NOT the outcome of the payment itself, see {@link PayonePaymentStatusCategory}).
+ * `onlinepayments-sdk-nodejs` types this field as a bare `string | null` (it ships no enums at
+ * all), so these are declared here from PAYONE's own status reference
+ * (https://developer.payone.com/en/integration/api-developer-guide/statuses).
+ */
+export enum PayoneCheckoutStatus {
+  Created = "CREATED",
+  InProgress = "IN_PROGRESS",
+  Redirected = "REDIRECTED",
+  /** Reached once a payment object exists for the checkout - for both approved *and declined*
+   * payments alike. Never sufficient on its own to determine success. */
+  PaymentCreated = "PAYMENT_CREATED",
+  CancelledByConsumer = "CANCELLED_BY_CONSUMER",
+}
+
+/**
+ * `CreatedPaymentOutput.paymentStatusCategory` values - the actual outcome of the payment
+ * underlying a hosted checkout. This, not {@link PayoneCheckoutStatus}, is what determines
+ * success/failure.
+ */
+export enum PayonePaymentStatusCategory {
+  Successful = "SUCCESSFUL",
+  Rejected = "REJECTED",
+  StatusUnknown = "STATUS_UNKNOWN",
+}
+
+/**
  * Configuration options for {@link PayoneProvider}.
  * These come from the per-customer plugin config (`plugins.json`), not from code constants.
  */


### PR DESCRIPTION
- checkout.status reaching PAYMENT_CREATED only means a payment object was created, not that it was approved - PAYONE reaches that status for declined payments too, so isSuccess previously misreported failed/3DS-declined payments as successful
- read createdPaymentOutput.paymentStatusCategory instead, in both handleStatus and checkStatus
- add PayoneCheckoutStatus/PayonePaymentStatusCategory enums in types.ts since the SDK types these fields as bare strings