### PR TITLE
fix(payone): capture immediately, reject unauthenticated 3DS, bump to…

### DIFF
--- a/packages/front-core/components/JsonSchema/elements/Payment/index.js
+++ b/packages/front-core/components/JsonSchema/elements/Payment/index.js
@@ -46,6 +46,8 @@ class Payment extends React.Component {
       timeout: null,
       inited: false,
       successMessageShown: false,
+      paymentFailed: false,
+      failureMessageShown: false,
     };
   }
 
@@ -115,9 +117,11 @@ class Payment extends React.Component {
 
     this.setState({ loading: false });
 
-    const { isSuccess } = this.state;
+    const { isSuccess, paymentFailed } = this.state;
 
-    if (!isSuccess && !silent) {
+    // `parseResult` already dispatched 'ErrorPaymentStatus' for a terminal failure - don't also
+    // tell the user it's merely pending.
+    if (!isSuccess && !paymentFailed && !silent) {
       importActions.addMessage(new Message('PendingPaymentStatus', 'warning'));
     }
   };
@@ -141,10 +145,16 @@ class Payment extends React.Component {
       ? amount.reduce((sum, item) => sum + item.amount, 0)
       : amount;
 
+    const hasProcessed =
+      typeof processed !== 'undefined' && processed.length > 0;
+
     const isSuccess =
-      (typeof processed !== 'undefined' &&
-        !!processed[processed.length - 1].status.isSuccess) ||
+      (hasProcessed && !!processed[processed.length - 1].status.isSuccess) ||
       false;
+
+    // A terminal (processed) attempt that did not succeed - as opposed to no attempt having
+    // completed yet, which is a normal pending state, not a failure.
+    const paymentFailed = hasProcessed && !isSuccess;
 
     const alreadyPassed =
       (typeof value.processed !== 'undefined' &&
@@ -153,15 +163,32 @@ class Payment extends React.Component {
 
     isSuccess && !alreadyPassed && (await importActions.loadTask(taskId));
 
-    if (isSuccess && !this.state.successMessageShown) {
-      importActions.addMessage(new Message('SuccessPaymentStatus', 'success'));
-      this.setState({ successMessageShown: true });
+    // Guarded via the setState updater form (reading `prevState`, not `this.state`) rather than
+    // a plain `!this.state.xShown` check - `parseResult` can run twice in close succession (e.g.
+    // around the PAYONE redirect-return page load), and reading `this.state` directly races
+    // against React's batching of the *other* call's pending `setState`, letting both calls see
+    // the flag as still unset and both dispatch a toast.
+    if (isSuccess) {
+      this.setState((prevState) => {
+        if (prevState.successMessageShown) return null;
+        importActions.addMessage(new Message('SuccessPaymentStatus', 'success'));
+        return { successMessageShown: true };
+      });
+    }
+
+    if (paymentFailed) {
+      this.setState((prevState) => {
+        if (prevState.failureMessageShown) return null;
+        importActions.addMessage(new Message('ErrorPaymentStatus', 'error'));
+        return { failureMessageShown: true };
+      });
     }
 
     this.setState({
       paymentValue: paymentValue && paymentValue.toFixed(2),
       paymentRequestData,
       isSuccess,
+      paymentFailed,
     });
   };
 
@@ -233,9 +260,12 @@ class Payment extends React.Component {
       isConfirmed,
     });
 
-    const { isSuccess } = this.state;
+    const { isSuccess, paymentFailed } = this.state;
 
+    // `parseResult` already dispatched 'ErrorPaymentStatus' for a terminal failure - don't also
+    // tell the user it's merely pending.
     !isSuccess &&
+      !paymentFailed &&
       importActions.addMessage(new Message('PendingPaymentStatus', 'warning'));
   };
 
@@ -276,6 +306,12 @@ class Payment extends React.Component {
       const { isSuccess } = this.state;
 
       if (!isSuccess) {
+        // A previous attempt may have already failed (persisted in the document's `processed`
+        // history, re-read by `checkPaymentStatus` above on every mount) - reset the shown-once
+        // flag so this fresh attempt can surface its own failure toast if it fails too, instead
+        // of being permanently suppressed by the last one.
+        this.setState({ failureMessageShown: false });
+
         const res = await importActions.getPaymentInfo(id, {
           paymentControlPath,
         });

--- a/packages/task-payone-plugin/package-lock.json
+++ b/packages/task-payone-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liquio/task-payone-plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@liquio/task-payone-plugin",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@liquio/plugin-sdk": "^0.1.5",
@@ -521,22 +521,22 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-DbeLFquQJyYGwM3LzPdjvb4IRmAAQuTzEmqUGtIAYxlAO4ArfUZ7WMytLWDSsCAYm6MZJNeojaawQQiFrFVehg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "2.0.1",
+        "@emnapi/wasi-threads": "2.1.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-SS4jUXRklsrPKTEtW92WHdneh9QBrZGmRyeYEac2ktLN3ie1wd/BrkBbk4DqPWKhjSFfrR8NClXwMlfZ73m60A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
-      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.1.0.tgz",
+      "integrity": "sha512-DM18NXgQ5coifswrwhFgrqeW/UiFRaLj0aLKU0cp0FoYjEfP/hj/yUeF+Hz754ViG+jQmG2HIeDCUeQsPnRwOA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2104,9 +2104,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2304,9 +2304,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4376,9 +4376,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4958,9 +4958,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/task-payone-plugin/package.json
+++ b/packages/task-payone-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquio/task-payone-plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "description": "PAYONE Platform payment provider plugin for components/task, built on @liquio/plugin-sdk",
   "main": "dist/index.js",

--- a/packages/task-payone-plugin/src/payone_provider.spec.ts
+++ b/packages/task-payone-plugin/src/payone_provider.spec.ts
@@ -575,7 +575,7 @@ describe("PayoneProvider", () => {
       );
     });
 
-    it("returns a failure shape when paymentStatusCategory is SUCCESSFUL but 3-D Secure authenticationStatus is \"U\" (unable to authenticate)", async () => {
+    it('returns a failure shape when paymentStatusCategory is SUCCESSFUL but 3-D Secure authenticationStatus is "U" (unable to authenticate)', async () => {
       // PAYONE's sandbox has been observed authorizing (and, with authorizationMode: "SALE",
       // capturing) payments for cards whose 3DS authentication never actually completed
       // ("U"), with liability shifted to the merchant, instead of exhibiting the outcome its
@@ -607,7 +607,7 @@ describe("PayoneProvider", () => {
       expect(result.extraData.authenticationStatus).toBe("U");
     });
 
-    it("returns a success shape when paymentStatusCategory is SUCCESSFUL and 3-D Secure authenticationStatus is \"Y\" (authenticated)", async () => {
+    it('returns a success shape when paymentStatusCategory is SUCCESSFUL and 3-D Secure authenticationStatus is "Y" (authenticated)', async () => {
       getCheckoutRequestMock.mockResolvedValue({
         commerceCaseId: "commerce-case-1",
         checkoutId: "checkout-1",
@@ -961,7 +961,7 @@ describe("PayoneProvider", () => {
       expect(result).toMatchObject({ isSuccess: false });
     });
 
-    it("returns a failure shape when paymentStatusCategory is SUCCESSFUL but 3-D Secure authenticationStatus is \"U\"", async () => {
+    it('returns a failure shape when paymentStatusCategory is SUCCESSFUL but 3-D Secure authenticationStatus is "U"', async () => {
       getCheckoutRequestMock.mockResolvedValue({
         checkoutStatus: "COMPLETED",
         statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },

--- a/packages/task-payone-plugin/src/payone_provider.spec.ts
+++ b/packages/task-payone-plugin/src/payone_provider.spec.ts
@@ -1,6 +1,7 @@
 import { PluginContext } from "@liquio/plugin-sdk";
 
 const createCommerceCaseRequestMock = jest.fn();
+const createHostedCheckoutRawRequestMock = jest.fn();
 const getCheckoutRequestMock = jest.fn();
 const cancelOrderMock = jest.fn();
 const initMock = jest.fn();
@@ -8,14 +9,14 @@ const initMock = jest.fn();
 jest.mock("onlinepayments-sdk-nodejs", () => ({
   init: initMock.mockReturnValue({
     hostedCheckout: {
-      createHostedCheckout: (...args: unknown[]) =>
-        Promise.resolve(
+      createHostedCheckout: (...args: unknown[]) => {
+        createHostedCheckoutRawRequestMock(args[1]);
+        return Promise.resolve(
           createCommerceCaseRequestMock(args[0], {
             merchantReference: (args[1] as any).order.references
               .merchantReference,
             checkout: {
               amountOfMoney: (args[1] as any).order.amountOfMoney,
-              autoExecuteOrder: true,
               orderRequest: {
                 orderType: "FULL",
                 paymentMethodSpecificInput: {
@@ -33,7 +34,8 @@ jest.mock("onlinepayments-sdk-nodejs", () => ({
               response.checkout?.paymentResponse?.merchantAction?.redirectData
                 ?.redirectURL,
           },
-        })),
+        }));
+      },
       getHostedCheckout: (...args: unknown[]) =>
         Promise.resolve(getCheckoutRequestMock(args[0], args[1])).then(
           (response) => ({
@@ -50,6 +52,15 @@ jest.mock("onlinepayments-sdk-nodejs", () => ({
                   id: response.paymentExecutions?.[0]?.paymentExecutionId,
                   paymentOutput: {
                     references: response.references,
+                    cardPaymentMethodSpecificOutput:
+                      response.threeDSecureAuthenticationStatus
+                        ? {
+                            threeDSecureResults: {
+                              authenticationStatus:
+                                response.threeDSecureAuthenticationStatus,
+                            },
+                          }
+                        : undefined,
                   },
                 },
               },
@@ -154,7 +165,6 @@ describe("PayoneProvider", () => {
               amount: 10050,
               currencyCode: "EUR",
             },
-            autoExecuteOrder: true,
             orderRequest: {
               orderType: OrderType.Full,
               paymentMethodSpecificInput: {
@@ -178,6 +188,32 @@ describe("PayoneProvider", () => {
         amount: 100.5,
         currency: "EUR",
       });
+    });
+
+    it("requests authorizationMode SALE so PAYONE captures the order immediately instead of leaving it PENDING_CAPTURE", async () => {
+      createCommerceCaseRequestMock.mockResolvedValue({
+        commerceCaseId: "commerce-case-1",
+        checkout: {
+          checkoutId: "checkout-1",
+          paymentResponse: {
+            paymentExecutionId: "exec-1",
+            merchantAction: {
+              redirectData: {
+                redirectURL: "https://secure.payone.com/redirect/abc",
+              },
+            },
+          },
+        },
+      });
+
+      const provider = new PayoneProvider(context, options);
+      await provider.calculatePayment(resolvedData);
+
+      expect(createHostedCheckoutRawRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cardPaymentMethodSpecificInput: { authorizationMode: "SALE" },
+        }),
+      );
     });
 
     it("appends documentId/paymentControlPath onto returnUrl so handleStatus can identify the callback later", async () => {
@@ -539,6 +575,62 @@ describe("PayoneProvider", () => {
       );
     });
 
+    it("returns a failure shape when paymentStatusCategory is SUCCESSFUL but 3-D Secure authenticationStatus is \"U\" (unable to authenticate)", async () => {
+      // PAYONE's sandbox has been observed authorizing (and, with authorizationMode: "SALE",
+      // capturing) payments for cards whose 3DS authentication never actually completed
+      // ("U"), with liability shifted to the merchant, instead of exhibiting the outcome its
+      // own test-card documentation describes. Trusting paymentStatusCategory alone here would
+      // report those as successful payments.
+      getCheckoutRequestMock.mockResolvedValue({
+        commerceCaseId: "commerce-case-1",
+        checkoutId: "checkout-1",
+        checkoutStatus: "COMPLETED",
+        references: { merchantReference: "order-42" },
+        paymentExecutions: [{ paymentExecutionId: "exec-1" }],
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
+        threeDSecureAuthenticationStatus: "U",
+      });
+
+      const provider = new PayoneProvider(context, options);
+      const result = await provider.handleStatus(
+        "",
+        options,
+        "success",
+        identifyingParams,
+        {},
+      );
+
+      expect(result.status).toEqual({ isSuccess: false });
+      expect(result.extraData.paymentStatus).toBe(
+        PayonePaymentStatusCategory.Successful,
+      );
+      expect(result.extraData.authenticationStatus).toBe("U");
+    });
+
+    it("returns a success shape when paymentStatusCategory is SUCCESSFUL and 3-D Secure authenticationStatus is \"Y\" (authenticated)", async () => {
+      getCheckoutRequestMock.mockResolvedValue({
+        commerceCaseId: "commerce-case-1",
+        checkoutId: "checkout-1",
+        checkoutStatus: "COMPLETED",
+        references: { merchantReference: "order-42" },
+        paymentExecutions: [{ paymentExecutionId: "exec-1" }],
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
+        threeDSecureAuthenticationStatus: "Y",
+      });
+
+      const provider = new PayoneProvider(context, options);
+      const result = await provider.handleStatus(
+        "",
+        options,
+        "success",
+        identifyingParams,
+        {},
+      );
+
+      expect(result.status).toEqual({ isSuccess: true });
+      expect(result.extraData.authenticationStatus).toBe("Y");
+    });
+
     it("re-queries PAYONE and returns a failure shape for a still-open/non-terminal checkout, never trusting the incoming status", async () => {
       getCheckoutRequestMock.mockResolvedValue({
         commerceCaseId: "commerce-case-1",
@@ -867,6 +959,28 @@ describe("PayoneProvider", () => {
       );
 
       expect(result).toMatchObject({ isSuccess: false });
+    });
+
+    it("returns a failure shape when paymentStatusCategory is SUCCESSFUL but 3-D Secure authenticationStatus is \"U\"", async () => {
+      getCheckoutRequestMock.mockResolvedValue({
+        checkoutStatus: "COMPLETED",
+        statusOutput: { paymentStatus: PayonePaymentStatusCategory.Successful },
+        references: { merchantReference: "order-42" },
+        threeDSecureAuthenticationStatus: "U",
+      });
+
+      const provider = new PayoneProvider(context, options);
+      const result = await provider.checkStatus(
+        options,
+        "checkout-1",
+        "commerce-case-1",
+      );
+
+      expect(result).toMatchObject({
+        isSuccess: false,
+        paymentStatus: PayonePaymentStatusCategory.Successful,
+        authenticationStatus: "U",
+      });
     });
 
     it("throws a descriptive error when sessionId/invoiceId are missing", async () => {

--- a/packages/task-payone-plugin/src/payone_provider.ts
+++ b/packages/task-payone-plugin/src/payone_provider.ts
@@ -110,6 +110,13 @@ export class PayoneProvider extends TaskPaymentProvider<PayoneOptions> {
           merchantReference: payload.orderId,
         },
       },
+      // `authorizationMode: "SALE"` combines authorization and capture into a single step, so a
+      // completed checkout is actually settled - PAYONE's default (omitting this field) instead
+      // leaves the order authorized-only (`PENDING_CAPTURE`/`PENDING_MERCHANT`) until a separate
+      // `capturePayment` call is made, which this plugin never issues.
+      cardPaymentMethodSpecificInput: {
+        authorizationMode: "SALE",
+      },
       hostedCheckoutSpecificInput: {
         returnUrl,
         showResultPage: false,
@@ -372,10 +379,21 @@ export class PayoneProvider extends TaskPaymentProvider<PayoneOptions> {
     // ("can occur alongside declined payments when examining the nested createdPaymentOutput
     // properties"). The actual outcome is `createdPaymentOutput.paymentStatusCategory`
     // (SUCCESSFUL / REJECTED / STATUS_UNKNOWN).
+    const payment = checkout.createdPaymentOutput?.payment;
+    const authenticationStatus =
+      payment?.paymentOutput?.cardPaymentMethodSpecificOutput
+        ?.threeDSecureResults?.authenticationStatus;
+    // `authenticationStatus === "U"` ("unable to authenticate") means 3-D Secure was attempted
+    // but never actually completed - PAYONE's sandbox has been observed authorizing (and, with
+    // `authorizationMode: "SALE"` above, capturing) these payments anyway with liability shifted
+    // to the merchant, instead of exhibiting the outcome its own test-card documentation
+    // describes. Treat that as a failure regardless of `paymentStatusCategory` so a broken/
+    // unprovisioned 3DS check on PAYONE's side doesn't get reported as a successful payment on
+    // ours. A card that was never put through 3DS at all (no `threeDSecureResults`, e.g. a
+    // non-3DS payment method) is unaffected - only an explicit "U" forces failure.
     const isSuccess =
       checkout.createdPaymentOutput?.paymentStatusCategory ===
-      PayonePaymentStatusCategory.Successful;
-    const payment = checkout.createdPaymentOutput?.payment;
+        PayonePaymentStatusCategory.Successful && authenticationStatus !== "U";
 
     // `checkPrevTransaction` (per `document.ts#calculatePayment`'s only caller of this path with
     // it set) is used to check whether an already-`calculatePayment`'d checkout has *already*
@@ -420,6 +438,7 @@ export class PayoneProvider extends TaskPaymentProvider<PayoneOptions> {
         checkoutId,
         checkoutStatus: checkout.status,
         paymentStatus: checkout.createdPaymentOutput?.paymentStatusCategory,
+        authenticationStatus,
         checkPrevTransaction: Boolean(checkPrevTransaction),
         redirectUrl,
       },
@@ -566,14 +585,15 @@ export class PayoneProvider extends TaskPaymentProvider<PayoneOptions> {
    * The SDK method that actually matches "release a hold so funds get collected" is
    * `PaymentExecutionApiClient.capturePayment` (`CapturePaymentRequest`'s own JSDoc: "capture...
    * the amount that was authorized"). But `calculatePayment` above always sets
-   * `autoExecuteOrder: true` on the order it creates - PAYONE auto-executes/captures the order as
-   * soon as the checkout completes, so there is no separate authorize-then-hold step in this
-   * integration for `capturePayment` to ever apply to. Supporting a genuine hold/capture flow
-   * would require reworking `calculatePayment` to stop auto-executing.
+   * `cardPaymentMethodSpecificInput.authorizationMode: "SALE"` on the order it creates - PAYONE
+   * auto-executes/captures a "SALE" order as soon as the checkout completes, so there is no
+   * separate authorize-then-hold step in this integration for `capturePayment` to ever apply to.
+   * Supporting a genuine hold/capture flow would require reworking `calculatePayment` to use
+   * `"PRE_AUTHORIZATION"`/`"FINAL_AUTHORIZATION"` instead of `"SALE"`.
    */
   async unHoldOrder(_data: unknown): Promise<never> {
     throw new Error(
-      "unHoldOrder is not supported by the Payone provider (calculatePayment always creates an auto-executed order - Payone captures funds immediately on checkout completion, so there is no separate authorization hold to release in this integration).",
+      "unHoldOrder is not supported by the Payone provider (calculatePayment always creates a SALE-mode order - Payone captures funds immediately on checkout completion, so there is no separate authorization hold to release in this integration).",
     );
   }
 
@@ -606,18 +626,25 @@ export class PayoneProvider extends TaskPaymentProvider<PayoneOptions> {
       if (!response.isSuccess) throw this.formatSdkResponseError(response);
       const checkout = response.body;
       const payment = checkout.createdPaymentOutput?.payment;
-      // See the matching comment in `handleStatus` above: checkout-level status reaching
+      // See the matching comments in `handleStatus` above: checkout-level status reaching
       // "PAYMENT_CREATED" does not imply the payment was approved - `paymentStatusCategory` is
-      // the actual outcome.
+      // the actual outcome - and `authenticationStatus === "U"` overrides that to a failure since
+      // PAYONE's sandbox has been observed authorizing/capturing these anyway instead of
+      // reflecting its own documented test-card outcomes.
+      const authenticationStatus =
+        payment?.paymentOutput?.cardPaymentMethodSpecificOutput
+          ?.threeDSecureResults?.authenticationStatus;
       const isSuccess =
         checkout.createdPaymentOutput?.paymentStatusCategory ===
-        PayonePaymentStatusCategory.Successful;
+          PayonePaymentStatusCategory.Successful &&
+        authenticationStatus !== "U";
 
       return {
         isSuccess,
         checkoutId: sessionId,
         hostedCheckoutStatus: checkout.status,
         paymentStatus: checkout.createdPaymentOutput?.paymentStatusCategory,
+        authenticationStatus,
         orderId: payment?.paymentOutput?.references?.merchantReference,
         paymentId: payment?.id,
       };


### PR DESCRIPTION
… 0.1.7

- set cardPaymentMethodSpecificInput.authorizationMode to SALE so a completed checkout is captured right away instead of sitting authorized-only in PENDING_CAPTURE with no separate capture call
- treat threeDSecureResults.authenticationStatus "U" as a payment failure regardless of paymentStatusCategory, since PAYONE's sandbox has been observed authorizing/capturing payments whose 3DS check never actually completed
- surface authenticationStatus in handleStatus/checkStatus extraData for audit visibility
- show an ErrorPaymentStatus toast when a payment terminally fails, instead of leaving the user with no feedback at all, guarding it via the setState updater form so rapid re-renders around the PAYONE redirect-return page can't double-dispatch it
- run npm audit fix and npm dedupe on task-payone-plugin