### PR TITLE
feat(auth): make login options config-driven

### DIFF
--- a/components/id-api/src/config/index.ts
+++ b/components/id-api/src/config/index.ts
@@ -7,6 +7,12 @@ export const DEFAULT_COOKIE_DOMAIN = '.liquio';
 export const DEFAULT_CODE_RETRIES = 5;
 export const DEFAULT_CODE_LENGTH = 6;
 
+export interface AuthProviderDisplay {
+  title?: string;
+  icon?: string;
+  description?: string;
+}
+
 export interface OIDCProviderConfig {
   issuer?: string;
   authorizationURL?: string;
@@ -20,6 +26,7 @@ export interface OIDCProviderConfig {
   mapping?: Record<string, string>;
   userInfo?: { enabled: boolean };
   usePKCE?: boolean;
+  display?: AuthProviderDisplay;
 }
 
 export interface Config {
@@ -129,10 +136,16 @@ export interface Config {
     local?: {
       isEnabled?: boolean;
       isForgotPasswordEnabled?: boolean;
+      display?: AuthProviderDisplay;
     };
-    wso2?: any;
+    wso2?: {
+      isEnabled?: boolean;
+      display?: AuthProviderDisplay;
+      [key: string]: any;
+    };
     x509?: {
       isEnabled?: boolean;
+      display?: AuthProviderDisplay;
     };
     oauth2?: StrategyOptions & { userProfileUrl: string };
     oidc?: {

--- a/components/id-api/src/controllers/auth.controller.ts
+++ b/components/id-api/src/controllers/auth.controller.ts
@@ -5,6 +5,7 @@ import { URL } from 'url';
 import { promisify } from 'util';
 
 import { DEFAULT_COOKIE_DOMAIN } from '../config';
+import { getEnabledAuthProviders } from '../lib/auth_providers';
 import { avatarByGender } from '../lib/helpers';
 import { prepareLoginHistoryData } from '../lib/login_history_extractor';
 import { ServerCrypt } from '../lib/server_crypt';
@@ -24,6 +25,7 @@ export class AuthController extends BaseController {
     const authMiddleware = AuthMiddleware.get();
 
     this.router.get('/auth', this.service('auth').prepareUser('approve'), authMiddleware.checkUserAccess(), this.getAuth.bind(this));
+    this.router.get('/auth_providers', this.getAuthProviders.bind(this));
     this.router.get('/sign_in', this.signIn.bind(this));
     this.router.get('/sign_in/requirements', this.signInRequirements.bind(this));
     this.router.get('/sign_in/requirements_phone', this.service('auth').prepareClient(), this.signInRequirementsPhone.bind(this));
@@ -64,6 +66,13 @@ export class AuthController extends BaseController {
   defaultRoute(req: Request, res: Response) {
     if (req.isAuthenticated()) res.send({ success: true, redirect: '/authorise/continue' });
     else res.redirect('/sign_in');
+  }
+
+  /**
+   * List currently enabled login options for the login page.
+   */
+  getAuthProviders(req: Request, res: Response): void {
+    res.send({ providers: getEnabledAuthProviders(this.config) });
   }
 
   signIn(req: Request, res: Response) {

--- a/components/id-api/src/lib/auth_providers.ts
+++ b/components/id-api/src/lib/auth_providers.ts
@@ -1,0 +1,52 @@
+import { AuthProviderDisplay, Config } from '../config';
+
+export interface AuthProviderOption {
+  type: 'local' | 'x509' | 'wso2' | 'oidc';
+  id: string;
+  url: string | null;
+  title?: string;
+  icon?: string;
+  description?: string;
+}
+
+function toOption(type: AuthProviderOption['type'], id: string, url: string | null, display?: AuthProviderDisplay): AuthProviderOption {
+  return {
+    type,
+    id,
+    url,
+    title: display?.title,
+    icon: display?.icon,
+    description: display?.description,
+  };
+}
+
+/**
+ * Enumerate currently enabled login options for the frontend, mirroring the
+ * enable checks in middleware/authenticate.ts so this list never drifts from
+ * which strategies are actually registered.
+ */
+export function getEnabledAuthProviders(config: Config): AuthProviderOption[] {
+  const authProviders = config.auth_providers ?? {};
+  const options: AuthProviderOption[] = [];
+
+  if (authProviders.local?.isEnabled) {
+    options.push(toOption('local', 'local', null, authProviders.local.display));
+  }
+
+  if (authProviders.x509?.isEnabled) {
+    options.push(toOption('x509', 'x509', null, authProviders.x509.display));
+  }
+
+  if (authProviders.wso2?.isEnabled) {
+    options.push(toOption('wso2', 'wso2', '/authorise/wso2', authProviders.wso2.display));
+  }
+
+  for (const [providerId, provider] of Object.entries(authProviders.oidc ?? {})) {
+    if (provider.isEnabled === false) {
+      continue;
+    }
+    options.push(toOption('oidc', providerId, `/authorise/oidc/${providerId}`, provider.display));
+  }
+
+  return options;
+}

--- a/components/id-front/public/config.json
+++ b/components/id-front/public/config.json
@@ -8,7 +8,6 @@
   "SHOW_PHONE": false,
   "SHOW_PHONE_CONFIRM": false,
   "FORCE_REGISTER": true,
-  "passwordAuth": true,
   "defaultLanguage": "en",
   "variables": {
     "dateFormat": "DD.MM.YYYY",

--- a/components/id-front/src/helpers/authProvidersLoader.js
+++ b/components/id-front/src/helpers/authProvidersLoader.js
@@ -1,0 +1,37 @@
+import { getConfig } from './configLoader';
+
+let providers = null;
+
+/**
+ * Load the list of currently enabled login options from id-api.
+ * Falls back to an empty list if the request fails, so the login page
+ * still renders (with no auth buttons instead of crashing).
+ */
+export async function loadAuthProviders() {
+  if (providers) {
+    return providers;
+  }
+
+  try {
+    const { BACKEND_URL } = getConfig();
+    const base = BACKEND_URL + (BACKEND_URL.charAt(BACKEND_URL.length - 1) !== '/' ? '/' : '');
+    const response = await fetch(`${base}auth_providers`, { credentials: 'include' });
+    if (!response.ok) {
+      throw new Error(`Failed to load auth providers: ${response.status}`);
+    }
+    const data = await response.json();
+    providers = Array.isArray(data.providers) ? data.providers : [];
+  } catch (error) {
+    console.error('Failed to load auth providers:', error);
+    providers = [];
+  }
+
+  return providers;
+}
+
+/**
+ * Get the cached auth providers list (must call loadAuthProviders first).
+ */
+export function getAuthProviders() {
+  return providers || [];
+}

--- a/components/id-front/src/index.js
+++ b/components/id-front/src/index.js
@@ -1,4 +1,5 @@
 import { loadConfig } from 'helpers/configLoader';
+import { loadAuthProviders } from 'helpers/authProvidersLoader';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -12,7 +13,6 @@ const DEFAULT_CONFIG = {
   SHOW_PHONE: false,
   SHOW_PHONE_CONFIRM: false,
   FORCE_REGISTER: true,
-  passwordAuth: true,
   defaultLanguage: 'en',
 };
 
@@ -21,6 +21,9 @@ const initializeApp = async () => {
   try {
     // Load configuration first
     await loadConfig(DEFAULT_CONFIG);
+
+    // Load enabled login options
+    await loadAuthProviders();
 
     // Start the application
     const { default: App } = await import('./App');

--- a/components/id-front/src/pages/Login/components/MainPage.jsx
+++ b/components/id-front/src/pages/Login/components/MainPage.jsx
@@ -6,7 +6,7 @@ import withStyles from '@mui/styles/withStyles';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import renderHTML from 'react-render-html';
 
-import { getConfig } from 'helpers/configLoader';
+import { getAuthProviders } from 'helpers/authProvidersLoader';
 import { ReactComponent as KeyIcon } from 'assets/img/ic_key.svg';
 import WSOLogo from 'assets/img/wso2-logo.png';
 
@@ -132,45 +132,59 @@ const styles = (theme) => ({
 });
 
 
+const DEFAULT_TITLES = {
+  local: 'LoginAndPass',
+  x509: 'keySign',
+};
+
 const MainPage = ({ classes, t, setLoginByOwnKey, setCredentialMethod }) => {
-  const config = getConfig();
-  const { WSO2 = {} } = config;
+  const providers = getAuthProviders();
   const chooseLoginByOwnKey = () => setLoginByOwnKey(true);
   const chooseLoginByCredentialMethod = (props) => setCredentialMethod(props || true);
 
-  const handleRedirectWso2 = React.useCallback(() => {
-    window.location.href = '/authorise/wso2';
-  }, []);
+  const handleProviderClick = (provider) => {
+    if (provider.type === 'local') {
+      return chooseLoginByCredentialMethod();
+    }
+    if (provider.type === 'x509') {
+      return chooseLoginByOwnKey();
+    }
+    if (provider.url) {
+      window.location.href = provider.url;
+    }
+    return undefined;
+  };
 
   return (
     <div className={classes.root}>
       <div className={classes.actions}>
-        <Button className={classes.button} onClick={chooseLoginByOwnKey}>
-          <div className={classes.buttonWrapper}>
-            <KeyIcon className={classes.icon}></KeyIcon>
-            {t('keySign')}
-          </div>
-          <ChevronRightIcon></ChevronRightIcon>
-        </Button>
+        {providers.map((provider) => {
+          const titleKey = DEFAULT_TITLES[provider.type];
+          const title = provider.title || (titleKey ? t(titleKey) : provider.id);
 
-        {WSO2 && WSO2.enabled && (
-          <Button className={classes.button} onClick={handleRedirectWso2}>
-            <div className={classes.buttonWrapper}>
-              <img src={WSOLogo} className={classes.authLogo} alt="" />
-            </div>
-            <ChevronRightIcon></ChevronRightIcon>
-          </Button>
-        )}
-
-        {config.passwordAuth ? (
-          <Button className={classes.button} onClick={chooseLoginByCredentialMethod}>
-            <div className={classes.buttonWrapper}>
-              <KeyIcon className={classes.icon}></KeyIcon>
-              {t('LoginAndPass')}
-            </div>
-            <ChevronRightIcon></ChevronRightIcon>
-          </Button>
-        ) : null}
+          return (
+            <Button
+              key={`${provider.type}-${provider.id}`}
+              className={classes.button}
+              onClick={() => handleProviderClick(provider)}
+              title={provider.description || undefined}
+            >
+              <div className={classes.buttonWrapper}>
+                {provider.icon ? (
+                  <img src={provider.icon} className={classes.authLogo} alt="" />
+                ) : provider.type === 'wso2' ? (
+                  <img src={WSOLogo} className={classes.authLogo} alt="" />
+                ) : (
+                  <>
+                    <KeyIcon className={classes.icon}></KeyIcon>
+                    {title}
+                  </>
+                )}
+              </div>
+              <ChevronRightIcon></ChevronRightIcon>
+            </Button>
+          );
+        })}
       </div>
       <div className={classes.info}>
         <Typography className={classes.infoTitle}>{t('infoTitle')}</Typography>


### PR DESCRIPTION
- id-api exposes GET /auth_providers listing currently enabled local/x509/wso2/oidc providers with optional display metadata (title/icon/description), mirroring the enable checks already used to register each strategy
- id-front fetches that list at startup and renders login buttons generically instead of per-provider hardcoded flags, so a new provider (e.g. an OIDC one) needs no frontend changes
- drop the now-redundant passwordAuth flag from id-front config