### PR TITLE
fix(id-api): dedupe user_services on repeat oidc/x509/wso2 login

### DIFF
--- a/components/id-api/migrations/20250601000013-user_services_unique_provider.js
+++ b/components/id-api/migrations/20250601000013-user_services_unique_provider.js
@@ -1,0 +1,13 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS user_services_provider_provider_id_uidx
+        ON public.user_services USING btree (provider, provider_id);
+    `);
+  },
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS public.user_services_provider_provider_id_uidx;
+    `);
+  },
+};

--- a/components/id-api/src/strategies/oidc.ts
+++ b/components/id-api/src/strategies/oidc.ts
@@ -377,8 +377,7 @@ class OidcProvider {
       }
 
       if (!userData.ipn) {
-        userData.ipn =
-          existingUser?.ipn || `#${createHash('sha256').update(`${providerKey}:${userProviderId}`).digest('hex')}`;
+        userData.ipn = existingUser?.ipn || `#${createHash('sha256').update(`${providerKey}:${userProviderId}`).digest('hex')}`;
       }
 
       let user: UserAttributes;

--- a/components/id-api/src/strategies/oidc.ts
+++ b/components/id-api/src/strategies/oidc.ts
@@ -1,8 +1,10 @@
 import { Strategy as OAuth2Strategy } from 'passport-oauth2';
 import axios from 'axios';
+import { createHash } from 'crypto';
+
+import { Log } from '@liquio/back-core';
 
 import { CallbackFn, Express } from '../types';
-import { Log } from '@liquio/back-core';
 import { Models, UserAttributes } from '../models';
 import { OIDCProviderConfig } from '../config';
 import { PKCEOAuth2Strategy, generatePKCEParameters } from './passport_libs/passport-oidc/strategy';
@@ -352,14 +354,31 @@ class OidcProvider {
         }
       }
 
+      const providerKey = `oidc-${providerId}`;
+
       let existingUser: UserAttributes | null = null;
 
-      if (userData.email) {
+      const existingService = await Models.model('userServices')
+        .findOne({
+          where: { provider: providerKey, provider_id: userProviderId },
+        })
+        .then((row) => row?.dataValues);
+
+      if (existingService) {
+        existingUser = await Models.model('user')
+          .findOne({ where: { userId: existingService.userId } })
+          .then((row) => row?.dataValues as UserAttributes);
+      } else if (userData.email) {
         existingUser = await Models.model('user')
           .findOne({
             where: { email: userData.email },
           })
           .then((row) => row?.dataValues as UserAttributes);
+      }
+
+      if (!userData.ipn) {
+        userData.ipn =
+          existingUser?.ipn || `#${createHash('sha256').update(`${providerKey}:${userProviderId}`).digest('hex')}`;
       }
 
       let user: UserAttributes;
@@ -377,17 +396,20 @@ class OidcProvider {
 
       this.log.save(`${log_tag}|user-upsert`, { userId: user.userId, is_new: !existingUser }, 'info');
 
-      const userService = await Models.model('userServices').upsert({
-        userId: user.userId,
-        provider: `oidc-${providerId}`,
-        provider_id: userProviderId,
-        data: userInfo,
-      });
+      const userService = await Models.model('userServices').upsert(
+        {
+          userId: user.userId,
+          provider: providerKey,
+          provider_id: userProviderId,
+          data: userInfo,
+        },
+        { conflictFields: ['provider', 'provider_id'] },
+      );
 
       const session = {
         ...user,
-        provider: `oidc-${providerId}`,
-        services: { [`oidc-${providerId}`]: userService },
+        provider: providerKey,
+        services: { [providerKey]: userService },
       };
 
       this.log.save(`${log_tag}|authorize-success`, { userId: user.userId }, 'info');

--- a/components/id-api/src/strategies/wso2.ts
+++ b/components/id-api/src/strategies/wso2.ts
@@ -1,8 +1,9 @@
 import { Strategy } from 'passport-oauth2';
 import axios from 'axios';
 
-import { CallbackFn, Express } from '../types';
 import { Log } from '@liquio/back-core';
+
+import { CallbackFn, Express } from '../types';
 import { Models, UserAttributes } from '../models';
 
 export async function wso2(app: Express) {
@@ -106,12 +107,15 @@ export async function wso2(app: Express) {
               .then((row) => row.dataValues);
           }
 
-          const userService = await Models.model('userServices').upsert({
-            userId: (existingUser || newUser!).userId,
-            provider: 'wso2',
-            provider_id: providerId,
-            data: userInfo,
-          });
+          const userService = await Models.model('userServices').upsert(
+            {
+              userId: (existingUser || newUser!).userId,
+              provider: 'wso2',
+              provider_id: providerId,
+              data: userInfo,
+            },
+            { conflictFields: ['provider', 'provider_id'] },
+          );
 
           const session = {
             ...(existingUser || newUser!),

--- a/components/id-api/src/strategies/x509.ts
+++ b/components/id-api/src/strategies/x509.ts
@@ -1,6 +1,7 @@
 import { Strategy as PassportStrategy } from 'passport-strategy';
 
 import { Log } from '@liquio/back-core';
+
 import { Express, Request, Response } from '../types';
 import { saveSession } from '../middleware/session';
 import { SignatureInfoSigner, X509Service } from '../services/x509.service';
@@ -145,12 +146,15 @@ export async function x509(app: Express) {
         log.save('x509-strategy|authenticate|user-found', { userId: existingUser.userId }, 'info');
       }
 
-      const userService = await Models.model('userServices').upsert({
-        userId: (existingUser || newUser!).userId,
-        provider: 'x509',
-        provider_id: ipn,
-        data: userInfo,
-      });
+      const userService = await Models.model('userServices').upsert(
+        {
+          userId: (existingUser || newUser!).userId,
+          provider: 'x509',
+          provider_id: ipn,
+          data: userInfo,
+        },
+        { conflictFields: ['provider', 'provider_id'] },
+      );
 
       done(null, {
         ...(existingUser || newUser!),

--- a/components/id-api/tests/auth-oidc.e2e-spec.ts
+++ b/components/id-api/tests/auth-oidc.e2e-spec.ts
@@ -1,4 +1,9 @@
+import { createHash } from 'crypto';
+import nock from 'nock';
+import supertest from 'supertest';
+
 import { TestApp, config } from './test_app';
+import { Models } from '../src/models';
 
 describe('AuthController - OIDC', () => {
   let app: TestApp;
@@ -69,6 +74,18 @@ describe('AuthController - OIDC', () => {
           last_name: 'family_name',
         },
       },
+      'ipn-mapped-provider': {
+        isEnabled: true,
+        issuer: dexUrl,
+        clientID: 'test-oidc-client-id',
+        clientSecret: 'test-oidc-secret',
+        callbackURL: `http://localhost:${config.port}/authorise/oidc/ipn-mapped-provider/callback`,
+        mapping: {
+          first_name: 'given_name',
+          last_name: 'family_name',
+          ipn: 'national_id',
+        },
+      },
     };
     config.notify = { url: 'http://notify-service', authorization: 'bm90aWZ5Om5vdGlmeQ==' };
 
@@ -89,7 +106,7 @@ describe('AuthController - OIDC', () => {
   it('should setup OIDC provider successfully', async () => {
     const oidcInitLog = TestApp.logs.find((log) => log.type === 'oidc' && log.data?.status === 'initialized');
     expect(oidcInitLog).toBeDefined();
-    expect(oidcInitLog?.data?.providers).toBe(5);
+    expect(oidcInitLog?.data?.providers).toBe(6);
   });
 
   it('should fetch discovery metadata from issuer', async () => {
@@ -143,5 +160,85 @@ describe('AuthController - OIDC', () => {
     const response = await app.request().get('/authorise/oidc/mapped-provider');
 
     expect(response.status).toBe(302);
+  });
+
+  describe('ipn mapping', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should map a provider claim to ipn when configured', async () => {
+      const appClient = supertest.agent(`http://localhost:${config.port}`);
+      const sub = 'ipn-mapped-user-1';
+
+      const initialResponse = await appClient.get('/authorise/oidc/ipn-mapped-provider').redirects(0).expect(302);
+      const state = new URL(initialResponse.headers.location).searchParams.get('state');
+
+      nock(dexUrl).post('/token').reply(200, { access_token: 'access-token', token_type: 'Bearer', expires_in: 3600 });
+      nock(dexUrl).get('/userinfo').reply(200, {
+        sub,
+        given_name: 'Erika',
+        family_name: 'Mustermann',
+        national_id: '1234567890',
+      });
+
+      await appClient.get(`/authorise/oidc/ipn-mapped-provider/callback?code=fake-code&state=${state}`).redirects(0).expect(302);
+
+      const service = await Models.model('userServices')
+        .findOne({ where: { provider: 'oidc-ipn-mapped-provider', provider_id: sub } })
+        .then((row) => row?.dataValues);
+      expect(service).toBeDefined();
+
+      const user = await Models.model('user')
+        .findOne({ where: { userId: service!.userId } })
+        .then((row) => row?.dataValues);
+
+      expect(user?.ipn).toBe('1234567890');
+    });
+
+    it('should generate a deterministic fake ipn when the provider has no ipn claim', async () => {
+      const appClient = supertest.agent(`http://localhost:${config.port}`);
+      const sub = 'ipn-fallback-user-1';
+
+      const initialResponse = await appClient.get('/authorise/oidc/dex').redirects(0).expect(302);
+      const state = new URL(initialResponse.headers.location).searchParams.get('state');
+
+      nock(dexUrl).post('/token').reply(200, { access_token: 'access-token', token_type: 'Bearer', expires_in: 3600 });
+      nock(dexUrl).get('/userinfo').reply(200, {
+        sub,
+        name: 'No Ipn User',
+      });
+
+      await appClient.get(`/authorise/oidc/dex/callback?code=fake-code&state=${state}`).redirects(0).expect(302);
+
+      const service = await Models.model('userServices')
+        .findOne({ where: { provider: 'oidc-dex', provider_id: sub } })
+        .then((row) => row?.dataValues);
+      expect(service).toBeDefined();
+
+      const user = await Models.model('user')
+        .findOne({ where: { userId: service!.userId } })
+        .then((row) => row?.dataValues);
+
+      const expectedIpn = `#${createHash('sha256').update(`oidc-dex:${sub}`).digest('hex')}`;
+      expect(user?.ipn).toBe(expectedIpn);
+
+      // Deterministic: a second login for the same identity keeps the same generated ipn.
+      nock(dexUrl).post('/token').reply(200, { access_token: 'access-token-2', token_type: 'Bearer', expires_in: 3600 });
+      nock(dexUrl).get('/userinfo').reply(200, {
+        sub,
+        name: 'No Ipn User',
+      });
+
+      const secondResponse = await appClient.get('/authorise/oidc/dex').redirects(0).expect(302);
+      const secondState = new URL(secondResponse.headers.location).searchParams.get('state');
+      await appClient.get(`/authorise/oidc/dex/callback?code=fake-code-2&state=${secondState}`).redirects(0).expect(302);
+
+      const userAfterSecondLogin = await Models.model('user')
+        .findOne({ where: { userId: service!.userId } })
+        .then((row) => row?.dataValues);
+
+      expect(userAfterSecondLogin?.ipn).toBe(expectedIpn);
+    });
   });
 });


### PR DESCRIPTION
- add unique index on user_services(provider, provider_id) and pass conflictFields to upsert() so repeat logins update the existing service row instead of inserting a duplicate
- oidc strategy now looks up the existing user via the linked user_services row before falling back to email match
- oidc strategy maps a configured claim to ipn, or generates a deterministic fake ipn (#sha256(provider:sub)) when the provider has none, so foreign identities always carry a unique key without colliding with real Ukrainian tax IDs