### PR TITLE
feat(id-api): add RP-initiated logout for OIDC providers

### DIFF
--- a/components/id-api/migrations/20250601000014-user_sessions_logout_data.js
+++ b/components/id-api/migrations/20250601000014-user_sessions_logout_data.js
@@ -1,0 +1,14 @@
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.query(`
+      ALTER TABLE public.user_sessions
+        ADD COLUMN IF NOT EXISTS logout_data jsonb NULL;
+    `);
+  },
+  async down(queryInterface) {
+    return queryInterface.sequelize.query(`
+      ALTER TABLE public.user_sessions
+        DROP COLUMN IF EXISTS logout_data;
+    `);
+  },
+};

--- a/components/id-api/src/config/index.ts
+++ b/components/id-api/src/config/index.ts
@@ -18,6 +18,7 @@ export interface OIDCProviderConfig {
   authorizationURL?: string;
   tokenURL?: string;
   userInfoURL?: string;
+  endSessionURL?: string;
   clientID: string;
   clientSecret: string;
   callbackURL: string;

--- a/components/id-api/src/middleware/authenticate.ts
+++ b/components/id-api/src/middleware/authenticate.ts
@@ -7,14 +7,16 @@ import { generatePinCode } from '../lib/helpers';
 import { prepareLoginHistoryData } from '../lib/login_history_extractor';
 import { Models, UserAttributes } from '../models';
 import { Services } from '../services';
-import { getStrategy, govid } from '../strategies/govid';
-import { local } from '../strategies/local';
-import { oidc } from '../strategies/oidc';
-import { wso2 } from '../strategies/wso2';
-import { x509 } from '../strategies/x509';
+import { govid, logout as govidLogout } from '../strategies/govid';
+import { local, logout as localLogout } from '../strategies/local';
+import { oidc, logout as oidcLogout } from '../strategies/oidc';
+import { wso2, logout as wso2Logout } from '../strategies/wso2';
+import { x509, logout as x509Logout } from '../strategies/x509';
 import { Express, NextFunction, Request, Response } from '../types';
 import { Log, appendTraceMeta } from '@liquio/back-core';
 import { destroySession, saveSession } from './session';
+
+type StrategyLogout = (req: Request) => Promise<{ endSessionUrl?: string } | void>;
 
 export class AuthMiddleware {
   private static singleton: AuthMiddleware;
@@ -64,6 +66,34 @@ export class AuthMiddleware {
       throw new Error('AuthMiddleware not initialized. Please call AuthMiddleware.init() first.');
     }
     return AuthMiddleware.singleton;
+  }
+
+  /**
+   * Every wired-up strategy exports a logout() (even if it's a no-op stub), so
+   * this always has something to call regardless of which provider logged the
+   * user in — no per-provider special-casing needed at the call site.
+   */
+  private resolveStrategyLogout(provider: string | undefined): StrategyLogout | undefined {
+    if (!provider) {
+      return undefined;
+    }
+
+    if (provider.startsWith('oidc-')) {
+      return oidcLogout;
+    }
+
+    switch (provider) {
+      case 'govid':
+        return govidLogout;
+      case 'wso2':
+        return wso2Logout;
+      case 'x509':
+        return x509Logout;
+      case 'local':
+        return localLogout;
+      default:
+        return undefined;
+    }
   }
 
   async init() {
@@ -144,7 +174,7 @@ export class AuthMiddleware {
     };
   }
 
-  private async onLogout(req: Request, res: Response) {
+  private async onLogout(req: Request, res: Response, endSessionUrl?: string) {
     const loginHistoryData = prepareLoginHistoryData(req, { actionType: 'logout' });
 
     let { redirect_uri: redirectUri } = matchedData(req, { locations: ['query'] });
@@ -159,29 +189,40 @@ export class AuthMiddleware {
     if (loginHistoryData) {
       await Models.model('loginHistory').create(loginHistoryData);
     }
-    // Redirect to `/` if custom redirect not defined.
-    if (!req.query.redirect_uri) {
-      return res.redirect('/');
+
+    let finalRedirect = '/';
+    if (req.query.redirect_uri) {
+      const clients = await Models.model('client')
+        .findAll()
+        .then((rows) => rows.map((row) => row.dataValues));
+      const clientsRedirectUri: string[] = clients.map((v) => v.redirectUri).reduce((t, v) => [...t, ...v], []);
+
+      finalRedirect = clientsRedirectUri.some((v) => redirectUri.startsWith(v)) ? redirectUri : '/';
     }
 
-    await Models.model('client')
-      .findAll()
-      .then((rows) => rows.map((row) => row.dataValues))
-      .then((clients) => {
-        const clientsRedirectUri: string[] = clients.map((v) => v.redirectUri).reduce((t, v) => [...t, ...v], []);
+    // No IdP session to terminate (or it's not an OIDC provider) — redirect as usual.
+    if (!endSessionUrl) {
+      return res.redirect(finalRedirect);
+    }
 
-        const isAllowedRedirectUri = clientsRedirectUri.some((v) => redirectUri.startsWith(v));
-        if (!isAllowedRedirectUri) {
-          redirectUri = '/';
-        }
+    // RP-initiated logout: send the browser to the IdP's end_session_endpoint
+    // so it actually kills its own SSO session, telling it to bounce the user
+    // back to the redirect we would otherwise have used directly.
+    const absoluteRedirect = finalRedirect.startsWith('http')
+      ? finalRedirect
+      : new URL(finalRedirect, `${req.protocol}://${req.get('host')}`).toString();
 
-        res.redirect(redirectUri);
-      });
+    const logoutUrl = new URL(endSessionUrl);
+    logoutUrl.searchParams.set('post_logout_redirect_uri', absoluteRedirect);
+
+    res.redirect(logoutUrl.toString());
   }
 
   logout(): (req: Request, res: Response, next: NextFunction) => Promise<void> | void {
     return async (req: Request, res: Response) => {
       let { passport } = req.session;
+
+      let endSessionUrl: string | undefined;
 
       if (passport && 'user' in passport) {
         let { user } = passport,
@@ -201,21 +242,26 @@ export class AuthMiddleware {
           });
         }
 
-        await Models.model('accessToken').destroy({ where: { userId } });
-        await Models.model('refreshToken').destroy({ where: { userId } });
-        await Models.model('sessions').destroy({ where: { userId: userId } });
-
-        if (provider === 'govid') {
+        // Must run before the user_sessions bulk-destroy below: RP-initiated
+        // logout reads the id_token/end_session_endpoint back from this login's
+        // session row, which that destroy would otherwise wipe out first.
+        const strategyLogout = this.resolveStrategyLogout(provider);
+        if (strategyLogout) {
           try {
-            await getStrategy().logout(user.services[provider]);
+            const result = await strategyLogout(req);
+            endSessionUrl = result?.endSessionUrl;
           } catch (error: any) {
             this.log.save('logout-error', { error: error?.message ?? error.toString() }, 'error');
           }
         }
+
+        await Models.model('accessToken').destroy({ where: { userId } });
+        await Models.model('refreshToken').destroy({ where: { userId } });
+        await Models.model('sessions').destroy({ where: { userId } });
       }
 
       res.clearCookie('jwt', { domain: this.express.config.domain ?? DEFAULT_COOKIE_DOMAIN });
-      req.logout(() => this.onLogout(req, res));
+      req.logout(() => this.onLogout(req, res, endSessionUrl));
     };
   }
 

--- a/components/id-api/src/models/sessions.model.ts
+++ b/components/id-api/src/models/sessions.model.ts
@@ -5,6 +5,11 @@ export interface SessionsAttributes {
   userId: string;
   expires: Date;
   data: string;
+  // Whatever a strategy needs to terminate this specific session upstream
+  // (e.g. OIDC's { id_token, end_session_endpoint }). Tied to the login
+  // session itself, not the permanent user_services account link, so it
+  // disappears with it. Generic on purpose so other strategies can reuse it.
+  logout_data?: Record<string, any> | null;
 }
 
 export class SessionsModel extends BaseModel<SessionsAttributes> {
@@ -21,6 +26,10 @@ export class SessionsModel extends BaseModel<SessionsAttributes> {
         userId: DataTypes.STRING(24),
         expires: DataTypes.DATE,
         data: DataTypes.STRING(50000),
+        logout_data: {
+          type: DataTypes.JSONB,
+          allowNull: true,
+        },
       },
       {
         timestamps: false,

--- a/components/id-api/src/strategies/govid.ts
+++ b/components/id-api/src/strategies/govid.ts
@@ -22,6 +22,17 @@ export function getStrategy(): GovIdStrategy {
   return strategy;
 }
 
+export async function logout(
+  req: { session?: { passport?: { user?: { provider?: string; services?: Record<string, any> } } } } | undefined,
+): Promise<void> {
+  const user = req?.session?.passport?.user;
+  if (user?.provider !== 'govid' || !strategy) {
+    return;
+  }
+
+  await strategy.logout(user.services?.[user.provider]);
+}
+
 export async function govid(app: Express) {
   const log = Log.getInstance();
   const passport = app.passport;

--- a/components/id-api/src/strategies/local.ts
+++ b/components/id-api/src/strategies/local.ts
@@ -11,6 +11,9 @@ import { CallbackFn, Express, Request, Response } from '../types';
 
 const GENERIC_FAIL_DESCRIPTION = 'Invalid email or password.';
 
+// No external IdP session to tear down for local (email/password) auth.
+export async function logout(): Promise<void> {}
+
 export async function local(app: Express) {
   const log = Log.getInstance();
 

--- a/components/id-api/src/strategies/oidc.ts
+++ b/components/id-api/src/strategies/oidc.ts
@@ -1,4 +1,3 @@
-import { Strategy as OAuth2Strategy } from 'passport-oauth2';
 import axios from 'axios';
 import { createHash } from 'crypto';
 
@@ -13,6 +12,7 @@ interface OIDCMetadata {
   authorization_endpoint: string;
   token_endpoint: string;
   userinfo_endpoint: string;
+  end_session_endpoint?: string;
 }
 
 interface OIDCProviderRuntimeState {
@@ -95,9 +95,12 @@ class OidcProvider {
     try {
       const metadata = await this.resolveOIDCEndpoints(providerId, provider);
       const strategyName = `oidc-${providerId}`;
-      const strategyClass = provider.usePKCE ? PKCEOAuth2Strategy : OAuth2Strategy;
 
-      const strategyInstance = new (strategyClass as any)(
+      // Always use the PKCE-capable strategy: it behaves exactly like plain
+      // OAuth2Strategy unless PKCE params are set, and it's also what lets us
+      // capture the id_token needed for RP-initiated logout on any provider.
+      let strategyInstance!: PKCEOAuth2Strategy;
+      strategyInstance = new PKCEOAuth2Strategy(
         {
           authorizationURL: metadata.authorization_endpoint,
           tokenURL: metadata.token_endpoint,
@@ -107,15 +110,14 @@ class OidcProvider {
           scope: provider.scope || 'openid profile email',
           passReqToCallback: true,
         },
-        (req: any, accessToken: string, refreshToken: string, profile: any, done: CallbackFn) =>
-          this.verifyOIDCUser(providerId, provider, metadata, accessToken, done),
+        (req: any, accessToken: string, refreshToken: string, profile: any, done: CallbackFn) => {
+          const idToken = strategyInstance.consumeIdToken(accessToken);
+          return this.verifyOIDCUser(providerId, provider, metadata, accessToken, idToken, req, done);
+        },
       );
 
       this.app.passport.use(strategyName, strategyInstance);
-
-      if (provider.usePKCE && strategyInstance instanceof PKCEOAuth2Strategy) {
-        this.strategyInstances.set(strategyName, strategyInstance);
-      }
+      this.strategyInstances.set(strategyName, strategyInstance);
 
       this.providerStates.set(providerId, { status: 'initialized' });
       this.log.save(`oidc|${providerId}|strategy-registered`, { status: 'success', strategy_name: strategyName }, 'info');
@@ -200,6 +202,16 @@ class OidcProvider {
           req.session.save();
           await new Promise((resolve) => setTimeout(resolve, 250));
 
+          const oidcLogout = (req as any)._oidcLogout as { idToken: string; endSessionEndpoint: string } | undefined;
+          if (oidcLogout) {
+            await Models.model('sessions')
+              .update(
+                { logout_data: { provider: 'oidc', id_token: oidcLogout.idToken, end_session_endpoint: oidcLogout.endSessionEndpoint } },
+                { where: { sid: req.sessionID } },
+              )
+              .catch((error: any) => this.log.save(`oidc|${providerId}|logout-token-persist-error`, { error: error.message }, 'error'));
+          }
+
           this.log.save(`oidc|${providerId}|callback`, { status: 'success', userId: user.userId, isAuthenticated: req.isAuthenticated() }, 'info');
 
           res.redirect('/authorise/continue');
@@ -263,6 +275,7 @@ class OidcProvider {
         authorization_endpoint: provider.authorizationURL,
         token_endpoint: provider.tokenURL,
         userinfo_endpoint: provider.userInfoURL,
+        end_session_endpoint: provider.endSessionURL,
       };
     }
 
@@ -286,6 +299,7 @@ class OidcProvider {
           authorization_endpoint: data.authorization_endpoint,
           token_endpoint: data.token_endpoint,
           userinfo_endpoint: data.userinfo_endpoint,
+          end_session_endpoint: data.end_session_endpoint,
         },
         'info',
       );
@@ -294,6 +308,7 @@ class OidcProvider {
         authorization_endpoint: data.authorization_endpoint,
         token_endpoint: data.token_endpoint,
         userinfo_endpoint: data.userinfo_endpoint,
+        end_session_endpoint: data.end_session_endpoint,
       };
     } catch (error: any) {
       const response = error.response?.data;
@@ -310,6 +325,8 @@ class OidcProvider {
     provider: OIDCProviderConfig,
     metadata: OIDCMetadata,
     accessToken: string,
+    idToken: string | undefined,
+    req: any,
     done: CallbackFn,
   ): Promise<void> {
     const log_tag = `oidc|${providerId}|verify`;
@@ -395,7 +412,7 @@ class OidcProvider {
 
       this.log.save(`${log_tag}|user-upsert`, { userId: user.userId, is_new: !existingUser }, 'info');
 
-      const userService = await Models.model('userServices').upsert(
+      const [userServiceRecord] = await Models.model('userServices').upsert(
         {
           userId: user.userId,
           provider: providerKey,
@@ -408,8 +425,15 @@ class OidcProvider {
       const session = {
         ...user,
         provider: providerKey,
-        services: { [providerKey]: userService },
+        services: { [providerKey]: userServiceRecord.dataValues },
       };
+
+      // Stashed on `req` (not the session/user object) so the callback route can
+      // persist it onto this login's user_sessions row once it exists, without
+      // ever putting the id_token where it could be echoed back to the client.
+      if (idToken && metadata.end_session_endpoint) {
+        (req as any)._oidcLogout = { idToken, endSessionEndpoint: metadata.end_session_endpoint };
+      }
 
       this.log.save(`${log_tag}|authorize-success`, { userId: user.userId }, 'info');
 
@@ -442,4 +466,33 @@ class OidcProvider {
 export async function oidc(app: Express): Promise<void> {
   const provider = new OidcProvider(app);
   await provider.init();
+}
+
+/**
+ * RP-initiated logout: reads back the id_token + end_session_endpoint stashed
+ * on this login session at login time, and returns a Keycloak (or any OIDC
+ * provider) end-session URL for the caller to redirect the browser to, so the
+ * upstream SSO session is actually terminated instead of just the local one.
+ */
+export async function logout(
+  req: { session?: { passport?: { user?: { provider?: string } } }; sessionID?: string } | undefined,
+): Promise<{ endSessionUrl?: string } | void> {
+  const provider = req?.session?.passport?.user?.provider;
+  if (!provider?.startsWith('oidc-') || !req?.sessionID) {
+    return;
+  }
+
+  const sessionRow = await Models.model('sessions')
+    .findOne({ where: { sid: req.sessionID } })
+    .then((row) => row?.dataValues);
+
+  const logoutData = sessionRow?.logout_data as { id_token?: string; end_session_endpoint?: string } | null | undefined;
+  if (!logoutData?.id_token || !logoutData?.end_session_endpoint) {
+    return;
+  }
+
+  const endSessionUrl = new URL(logoutData.end_session_endpoint);
+  endSessionUrl.searchParams.set('id_token_hint', logoutData.id_token);
+
+  return { endSessionUrl: endSessionUrl.toString() };
 }

--- a/components/id-api/src/strategies/passport_libs/passport-oidc/strategy.ts
+++ b/components/id-api/src/strategies/passport_libs/passport-oidc/strategy.ts
@@ -6,6 +6,9 @@ import crypto from 'crypto';
  */
 export class PKCEOAuth2Strategy extends OAuth2Strategy {
   private pkceParams: { codeVerifier: string; codeChallenge: string } | null = null;
+  // id_token isn't forwarded to the verify callback by passport-oauth2, so it's
+  // stashed here keyed by access token (unique per exchange) and consumed once.
+  private idTokensByAccessToken = new Map<string, string>();
 
   constructor(options: any, verify: any) {
     super(options, verify);
@@ -17,12 +20,26 @@ export class PKCEOAuth2Strategy extends OAuth2Strategy {
       if (self.pkceParams) {
         params = { ...params, code_verifier: self.pkceParams.codeVerifier };
       }
-      return originalGetOAuthAccessToken(code, params, callback);
+      return originalGetOAuthAccessToken(code, params, (err: any, accessToken: string, refreshToken: string, tokenParams: any) => {
+        if (!err && accessToken && tokenParams?.id_token) {
+          self.idTokensByAccessToken.set(accessToken, tokenParams.id_token);
+        }
+        callback(err, accessToken, refreshToken, tokenParams);
+      });
     };
   }
 
   setPKCEParams(pkceParams: { codeVerifier: string; codeChallenge: string }) {
     this.pkceParams = pkceParams;
+  }
+
+  /**
+   * Returns the id_token captured for a given access token and forgets it.
+   */
+  consumeIdToken(accessToken: string): string | undefined {
+    const idToken = this.idTokensByAccessToken.get(accessToken);
+    this.idTokensByAccessToken.delete(accessToken);
+    return idToken;
   }
 
   authorizationParams(options: any) {

--- a/components/id-api/src/strategies/wso2.ts
+++ b/components/id-api/src/strategies/wso2.ts
@@ -6,6 +6,10 @@ import { Log } from '@liquio/back-core';
 import { CallbackFn, Express } from '../types';
 import { Models, UserAttributes } from '../models';
 
+// WSO2 doesn't support an external logout call today — kept as a stub so the
+// caller can always invoke a strategy's logout() uniformly.
+export async function logout(): Promise<void> {}
+
 export async function wso2(app: Express) {
   const log = Log.getInstance();
   const passport = app.passport;

--- a/components/id-api/src/strategies/x509.ts
+++ b/components/id-api/src/strategies/x509.ts
@@ -72,6 +72,10 @@ export class X509Strategy extends PassportStrategy {
   }
 }
 
+// x509 certificate auth has no external session to tear down — kept as a stub
+// so the caller can always invoke a strategy's logout() uniformly.
+export async function logout(): Promise<void> {}
+
 export async function x509(app: Express) {
   const log = Log.getInstance();
 

--- a/components/id-api/tests/auth-oidc.e2e-spec.ts
+++ b/components/id-api/tests/auth-oidc.e2e-spec.ts
@@ -86,6 +86,17 @@ describe('AuthController - OIDC', () => {
           ipn: 'national_id',
         },
       },
+      'logout-provider': {
+        isEnabled: true,
+        issuer: dexUrl,
+        clientID: 'test-oidc-client-id',
+        clientSecret: 'test-oidc-secret',
+        callbackURL: `http://localhost:${config.port}/authorise/oidc/logout-provider/callback`,
+        authorizationURL: `${dexUrl}/auth`,
+        tokenURL: `${dexUrl}/token`,
+        userInfoURL: `${dexUrl}/userinfo`,
+        endSessionURL: `${dexUrl}/session/end`,
+      },
     };
     config.notify = { url: 'http://notify-service', authorization: 'bm90aWZ5Om5vdGlmeQ==' };
 
@@ -106,7 +117,7 @@ describe('AuthController - OIDC', () => {
   it('should setup OIDC provider successfully', async () => {
     const oidcInitLog = TestApp.logs.find((log) => log.type === 'oidc' && log.data?.status === 'initialized');
     expect(oidcInitLog).toBeDefined();
-    expect(oidcInitLog?.data?.providers).toBe(6);
+    expect(oidcInitLog?.data?.providers).toBe(7);
   });
 
   it('should fetch discovery metadata from issuer', async () => {
@@ -239,6 +250,77 @@ describe('AuthController - OIDC', () => {
         .then((row) => row?.dataValues);
 
       expect(userAfterSecondLogin?.ipn).toBe(expectedIpn);
+    });
+  });
+
+  describe('RP-initiated logout', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should redirect to the provider end_session_endpoint with id_token_hint on logout', async () => {
+      const appClient = supertest.agent(`http://localhost:${config.port}`);
+      const sub = 'logout-user-1';
+
+      const initialResponse = await appClient.get('/authorise/oidc/logout-provider').redirects(0).expect(302);
+      const state = new URL(initialResponse.headers.location).searchParams.get('state');
+
+      nock(dexUrl).post('/token').reply(200, { access_token: 'access-token', token_type: 'Bearer', expires_in: 3600, id_token: 'fake-id-token' });
+      nock(dexUrl).get('/userinfo').reply(200, { sub, name: 'Logout User' });
+
+      await appClient.get(`/authorise/oidc/logout-provider/callback?code=fake-code&state=${state}`).redirects(0).expect(302);
+
+      const logoutResponse = await appClient.get('/logout').redirects(0).expect(302);
+
+      const logoutUrl = new URL(logoutResponse.headers.location);
+      expect(logoutUrl.origin + logoutUrl.pathname).toBe(`${dexUrl}/session/end`);
+      expect(logoutUrl.searchParams.get('id_token_hint')).toBe('fake-id-token');
+      expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(`http://localhost:${config.port}/`);
+    });
+
+    it('should persist logout_data on the session row, not on user_services', async () => {
+      const appClient = supertest.agent(`http://localhost:${config.port}`);
+      const sub = 'logout-user-2';
+
+      const initialResponse = await appClient.get('/authorise/oidc/logout-provider').redirects(0).expect(302);
+      const state = new URL(initialResponse.headers.location).searchParams.get('state');
+
+      nock(dexUrl)
+        .post('/token')
+        .reply(200, { access_token: 'access-token-2', token_type: 'Bearer', expires_in: 3600, id_token: 'another-id-token' });
+      nock(dexUrl).get('/userinfo').reply(200, { sub, name: 'Logout User Two' });
+
+      await appClient.get(`/authorise/oidc/logout-provider/callback?code=fake-code-2&state=${state}`).redirects(0).expect(302);
+
+      const service = await Models.model('userServices')
+        .findOne({ where: { provider: 'oidc-logout-provider', provider_id: sub } })
+        .then((row) => row?.dataValues);
+      expect(service).toBeDefined();
+      expect((service?.data as any)?.id_token).toBeUndefined();
+      expect((service?.data as any)?.end_session_endpoint).toBeUndefined();
+
+      const sessionRow = await Models.model('sessions')
+        .findOne({ where: { userId: service!.userId } })
+        .then((row) => row?.dataValues);
+
+      expect((sessionRow?.logout_data as any)?.id_token).toBe('another-id-token');
+      expect((sessionRow?.logout_data as any)?.end_session_endpoint).toBe(`${dexUrl}/session/end`);
+    });
+
+    it('should fall back to a normal redirect when the provider has no end_session_endpoint', async () => {
+      const appClient = supertest.agent(`http://localhost:${config.port}`);
+      const sub = 'logout-user-3';
+
+      const initialResponse = await appClient.get('/authorise/oidc/dex').redirects(0).expect(302);
+      const state = new URL(initialResponse.headers.location).searchParams.get('state');
+
+      nock(dexUrl).post('/token').reply(200, { access_token: 'access-token-3', token_type: 'Bearer', expires_in: 3600 });
+      nock(dexUrl).get('/userinfo').reply(200, { sub, name: 'No Logout User', email: 'no-logout@example.com' });
+
+      await appClient.get(`/authorise/oidc/dex/callback?code=fake-code-3&state=${state}`).redirects(0).expect(302);
+
+      const logoutResponse = await appClient.get('/logout').redirects(0).expect(302);
+      expect(logoutResponse.headers.location).toBe('/');
     });
   });
 });


### PR DESCRIPTION
- capture id_token from the OIDC token exchange (passport-oauth2 doesn't forward it) and persist it with end_session_endpoint in a new generic user_sessions.logout_data jsonb column, scoped to this login session rather than the permanent user_services account link
- every wired-up auth strategy now exports logout(req) (govid's existing external logout call included, others as no-op stubs), so AuthMiddleware.logout() dispatches uniformly instead of special-casing govid
- on logout, redirect the browser to the provider's end_session_endpoint with id_token_hint + post_logout_redirect_uri so Keycloak's SSO session is actually torn down instead of only the local one